### PR TITLE
refactor(frontend): use alias imports

### DIFF
--- a/frontend/luximia_erp_ui/app/(autenticacion)/authy-register/page.jsx
+++ b/frontend/luximia_erp_ui/app/(autenticacion)/authy-register/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import apiClient from '../../services/api';
+import apiClient from '@/services/api';
 
 export default function AuthyRegisterPage() {
     const [username, setUsername] = useState('');

--- a/frontend/luximia_erp_ui/app/(autenticacion)/enroll/[token]/page.jsx
+++ b/frontend/luximia_erp_ui/app/(autenticacion)/enroll/[token]/page.jsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import apiClient from '../../../../services/api';
+import apiClient from '@/services/api';
 
 export default function EnrollTokenPage() {
   const router = useRouter();

--- a/frontend/luximia_erp_ui/app/(autenticacion)/enroll/setup/page.jsx
+++ b/frontend/luximia_erp_ui/app/(autenticacion)/enroll/setup/page.jsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { Suspense, useEffect, useState } from 'react';
-import apiClient from '../../../../services/api';
+import apiClient from '@/services/api';
 import { startRegistration } from '@simplewebauthn/browser';
 import QRCode from 'react-qr-code';
 import { useRouter } from 'next/navigation';

--- a/frontend/luximia_erp_ui/app/(autenticacion)/login/page.jsx
+++ b/frontend/luximia_erp_ui/app/(autenticacion)/login/page.jsx
@@ -2,12 +2,12 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { useAuth } from '../../../context/AuthContext.jsx';
+import { useAuth } from '@/context/AuthContext';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { User, Key } from 'lucide-react';
 import { startAuthentication } from '@simplewebauthn/browser';
-import apiClient from '../../../services/api.js';
-import LoginAnimation from '../../../components/ui/LoginAnimation.jsx';
+import apiClient from '@/services/api';
+import LoginAnimation from '@/components/ui/LoginAnimation';
 
 export default function LoginPage() {
     const { setAuthData } = useAuth();

--- a/frontend/luximia_erp_ui/app/(catalogos)/bancos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/bancos/page.jsx
@@ -9,12 +9,12 @@ import {
   getInactiveBancos,
   hardDeleteBanco,
   exportBancosExcel
-} from '../../../services/api.js';
-import { useAuth } from '../../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import FormModal from '../../components/FormModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
-import ExportModal from '../../components/ExportModal';
+} from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import ExportModal from '@/components/ui/modals/Export';
 import { Download } from 'lucide-react';
 
 const BANCO_COLUMNAS_DISPLAY = [

--- a/frontend/luximia_erp_ui/app/(catalogos)/clientes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/clientes/page.jsx
@@ -2,14 +2,14 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getClientes, createCliente, updateCliente, deleteCliente, getInactiveClientes, hardDeleteCliente, exportClientesExcel } from '../../services/api';
-import { useAuth } from '../../context/AuthContext.jsx';
-import Modal from '../../components/ui/modals';
-import FormModal from '../../components/FormModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
-import ReusableTable from '../../components/ReusableTable';
-import { useResponsivePageSize } from '../../hooks/useResponsivePageSize';
-import ExportModal from '../../components/ExportModal';
+import { getClientes, createCliente, updateCliente, deleteCliente, getInactiveClientes, hardDeleteCliente, exportClientesExcel } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import Modal from '@/components/ui/modals';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
+import ExportModal from '@/components/ui/modals/Export';
 import { Download } from 'lucide-react';
 
 

--- a/frontend/luximia_erp_ui/app/(catalogos)/departamentos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/departamentos/page.jsx
@@ -1,11 +1,11 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getDepartamentos, createDepartamento, updateDepartamento, deleteDepartamento, getInactiveDepartamentos, hardDeleteDepartamento } from '../../services/api';
-import { useAuth } from '../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import FormModal from '../../components/FormModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
+import { getDepartamentos, createDepartamento, updateDepartamento, deleteDepartamento, getInactiveDepartamentos, hardDeleteDepartamento } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
 
 const DEPARTAMENTO_COLUMNAS_DISPLAY = [
     { header: 'Nombre', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.nombre}</span> },

--- a/frontend/luximia_erp_ui/app/(catalogos)/empleados/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/empleados/page.jsx
@@ -12,11 +12,11 @@ import {
     getDepartamentos,
     getPuestos,
     getUsers,
-} from '../../../services/api';
-import { useAuth } from '../../../context/AuthContext.jsx';
-import FormModal from '../../components/FormModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
-import ReusableTable from '../../components/ReusableTable';
+} from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
 
 const EMPLEADO_COLUMNAS_DISPLAY = [
     { header: 'Usuario', render: (row) => row.user_username },

--- a/frontend/luximia_erp_ui/app/(catalogos)/esquemas-comision/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/esquemas-comision/page.jsx
@@ -1,12 +1,12 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getEsquemasComision, createEsquemaComision, updateEsquemaComision, deleteEsquemaComision, getInactiveEsquemasComision, hardDeleteEsquemaComision } from '../../../services/api';
-import { useAuth } from '../../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import FormModal from '../../components/FormModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
-import { useResponsivePageSize } from '../../../hooks/useResponsivePageSize';
+import { getEsquemasComision, createEsquemaComision, updateEsquemaComision, deleteEsquemaComision, getInactiveEsquemasComision, hardDeleteEsquemaComision } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
 
 const ESQUEMA_COLUMNAS_DISPLAY = [
     { header: 'Esquema', render: (row) => <span className="text-gray-900 dark:text-white">{row.esquema}</span> },

--- a/frontend/luximia_erp_ui/app/(catalogos)/formas-pago/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/formas-pago/page.jsx
@@ -9,12 +9,12 @@ import {
   getInactiveFormasPago,
   hardDeleteFormaPago,
   exportFormasPagoExcel
-} from '../../services/api';
-import { useAuth } from '../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import FormModal from '../../components/FormModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
-import ExportModal from '../../components/ExportModal';
+} from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import ExportModal from '@/components/ui/modals/Export';
 import { Download } from 'lucide-react';
 
 const COLUMNS_DISPLAY = [

--- a/frontend/luximia_erp_ui/app/(catalogos)/monedas/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/monedas/page.jsx
@@ -9,12 +9,12 @@ import {
   getInactiveMonedas,
   hardDeleteMoneda,
   exportMonedasExcel
-} from '../../services/api';
-import { useAuth } from '../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import FormModal from '../../components/FormModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
-import ExportModal from '../../components/ExportModal';
+} from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import ExportModal from '@/components/ui/modals/Export';
 import { Download } from 'lucide-react';
 
 const MONEDA_COLUMNAS_DISPLAY = [

--- a/frontend/luximia_erp_ui/app/(catalogos)/planes-pago/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/planes-pago/page.jsx
@@ -1,12 +1,12 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getPlanesPago, createPlanPago, getClientes, getUPEs } from '../../services/api';
-import { useAuth } from '../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import FormModal from '../../components/FormModal';
-import { useResponsivePageSize } from '../../hooks/useResponsivePageSize';
-import Loader from '../../components/loaders/Loader';
+import { getPlanesPago, createPlanPago, getClientes, getUPEs } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form';
+import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
+import Loader from '@/components/loaders/Spinner';
 
 export default function PlanesPagoPage() {
     const { hasPermission } = useAuth();

--- a/frontend/luximia_erp_ui/app/(catalogos)/proyectos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/proyectos/page.jsx
@@ -2,15 +2,15 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getProyectos, createProyecto, updateProyecto, deleteProyecto, getInactiveProyectos, hardDeleteProyecto, exportProyectosExcel } from '../../services/api';
-import { useAuth } from '../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import FormModal from '../../components/FormModal'; // <-- Usa el FormModal
-import ExportModal from '../../components/ExportModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
+import { getProyectos, createProyecto, updateProyecto, deleteProyecto, getInactiveProyectos, hardDeleteProyecto, exportProyectosExcel } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form'; // <-- Usa el FormModal
+import ExportModal from '@/components/ui/modals/Export';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import { Download } from 'lucide-react';
-import { useResponsivePageSize } from '../../hooks/useResponsivePageSize';
-import { formatCurrency } from '../../utils/formatters';
+import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
+import { formatCurrency } from '@/utils/formatters';
 
 
 const PROYECTO_COLUMNAS_DISPLAY = [

--- a/frontend/luximia_erp_ui/app/(catalogos)/puestos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/puestos/page.jsx
@@ -1,11 +1,11 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getPuestos, createPuesto, updatePuesto, deletePuesto, getInactivePuestos, hardDeletePuesto, getAllDepartamentos } from '../../services/api';
-import { useAuth } from '../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import FormModal from '../../components/FormModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
+import { getPuestos, createPuesto, updatePuesto, deletePuesto, getInactivePuestos, hardDeletePuesto, getAllDepartamentos } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
 
 const PUESTO_COLUMNAS_DISPLAY = [
     { header: 'Nombre', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.nombre}</span> },

--- a/frontend/luximia_erp_ui/app/(catalogos)/tipos-cambio/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/tipos-cambio/page.jsx
@@ -1,12 +1,12 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getTiposCambio, createTipoCambio, updateTipoCambio, deleteTipoCambio } from '../../../services/api';
-import { useAuth } from '../../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import FormModal from '../../components/FormModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
-import { useResponsivePageSize } from '../../../hooks/useResponsivePageSize';
+import { getTiposCambio, createTipoCambio, updateTipoCambio, deleteTipoCambio } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
 
 const FORM_FIELDS = [
     { name: 'escenario', label: 'Escenario', required: true },

--- a/frontend/luximia_erp_ui/app/(catalogos)/tipos-de-cambio/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/tipos-de-cambio/page.jsx
@@ -2,10 +2,10 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getTiposDeCambio, actualizarTipoDeCambioHoy } from '../../../services/api';
-import { useAuth } from '../../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import { useResponsivePageSize } from '../../../hooks/useResponsivePageSize';
+import { getTiposDeCambio, actualizarTipoDeCambioHoy } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
 import { RefreshCcw } from 'lucide-react';
 
 export default function TiposDeCambioPage() {

--- a/frontend/luximia_erp_ui/app/(catalogos)/upes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/upes/page.jsx
@@ -2,13 +2,13 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getUPEs, getAllProyectos, createUPE, updateUPE, deleteUPE, getInactiveUpes, hardDeleteUpe, exportUpesExcel } from '../../services/api';
-import { useAuth } from '../../context/AuthContext.jsx';
-import FormModal from '../../components/FormModal';
-import ExportModal from '../../components/ExportModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
-import ReusableTable from '../../components/ReusableTable';
-import { formatCurrency } from '../../utils/formatters';
+import { getUPEs, getAllProyectos, createUPE, updateUPE, deleteUPE, getInactiveUpes, hardDeleteUpe, exportUpesExcel } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import FormModal from '@/components/ui/modals/Form';
+import ExportModal from '@/components/ui/modals/Export';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import { formatCurrency } from '@/utils/formatters';
 import { Download } from 'lucide-react';
 
 // ### 2. Define las columnas para la tabla y la exportación ###

--- a/frontend/luximia_erp_ui/app/(catalogos)/vendedores/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/vendedores/page.jsx
@@ -1,11 +1,11 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getVendedores, createVendedor, updateVendedor, deleteVendedor, getInactiveVendedores, hardDeleteVendedor } from '../../../services/api';
-import { useAuth } from '../../../context/AuthContext.jsx';
-import FormModal from '../../components/FormModal';
-import ConfirmationModal from '../../components/ConfirmationModal';
-import ReusableTable from '../../components/ReusableTable';
+import { getVendedores, createVendedor, updateVendedor, deleteVendedor, getInactiveVendedores, hardDeleteVendedor } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
 
 const VENDEDOR_COLUMNAS_DISPLAY = [
     { header: 'Tipo', render: (row) => row.tipo },

--- a/frontend/luximia_erp_ui/app/(configuraciones)/ajustes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/ajustes/page.jsx
@@ -1,8 +1,8 @@
 'use client';
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
-import { useAuth } from '../../../context/AuthContext.jsx';
-import { getUser, updateUser } from '../../../services/api.js';
+import { useAuth } from '@/context/AuthContext';
+import { getUser, updateUser } from '@/services/api';
 
 export default function AjustesPage() {
     const { user } = useAuth();

--- a/frontend/luximia_erp_ui/app/(configuraciones)/auditoria/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/auditoria/page.jsx
@@ -1,8 +1,8 @@
 'use client';
 import React, { useEffect, useState } from 'react';
-import ReusableTable from '../../components/ReusableTable';
-import { useAuth } from '../../context/AuthContext.jsx';
-import { getAuditLogs, downloadAuditLogExcel } from '../../services/api';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import { useAuth } from '@/context/AuthContext';
+import { getAuditLogs, downloadAuditLogExcel } from '@/services/api';
 
 const COLUMNAS = [
   { header: 'Usuario', render: row => row.user || '-' },

--- a/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/roles/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/roles/page.jsx
@@ -3,13 +3,13 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 // 1. Importa todo lo necesario
-import { getGroups, getPermissions, createGroup, updateGroup, deleteGroup } from '../../../services/api';
-import { useAuth } from '../../../context/AuthContext.jsx';
-import ReusableTable from '../../../components/ReusableTable';
-import FormModal from '../../../components/FormModal';
-import ConfirmationModal from '../../../components/ConfirmationModal';
-import { translatePermission, translateModel } from '../../../utils/permissions';
-import Loader from '../../../components/loaders/Loader';
+import { getGroups, getPermissions, createGroup, updateGroup, deleteGroup } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import { translatePermission, translateModel } from '@/utils/permissions';
+import Loader from '@/components/loaders/Spinner';
 
 // --- Constantes de Configuración ---
 

--- a/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/usuarios/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/usuarios/page.jsx
@@ -2,12 +2,12 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getUsers, getGroups, createUser, updateUser, deleteUser, getInactiveUsers, hardDeleteUser } from '../../../services/api';
-import { useAuth } from '../../../context/AuthContext.jsx';
-import ReusableTable from '../../../components/ReusableTable';
-import FormModal from '../../../components/FormModal';
-import ConfirmationModal from '../../../components/ConfirmationModal';
-import Loader from '../../../components/loaders/Loader';
+import { getUsers, getGroups, createUser, updateUser, deleteUser, getInactiveUsers, hardDeleteUser } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import FormModal from '@/components/ui/modals/Form';
+import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import Loader from '@/components/loaders/Spinner';
 
 const USUARIO_COLUMNAS_DISPLAY = [
     { header: 'Usuario', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.username}</span> },

--- a/frontend/luximia_erp_ui/app/(main)/dashboard/page.jsx
+++ b/frontend/luximia_erp_ui/app/(main)/dashboard/page.jsx
@@ -2,10 +2,10 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { getStrategicDashboardData, getAllProyectos } from '../../../services/api';
+import { getStrategicDashboardData, getAllProyectos } from '@/services/api';
 
 // Componentes de UI
-import Loader from '../../components/loaders/Loader';
+import Loader from '@/components/loaders/Spinner';
 import KpiCard from '@/components/ui/cards/Kpi';
 import VentasChart from '@/components/charts/Ventas';
 import FlujoCobranzaChart from '@/components/charts/FlujoCobranza';

--- a/frontend/luximia_erp_ui/app/(operaciones)/contratos/[id]/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/contratos/[id]/page.jsx
@@ -3,14 +3,14 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'next/navigation';
-import { getContratoById, createPago, updatePago, deletePago, descargarEstadoDeCuentaPDF, descargarEstadoDeCuentaExcel } from '../../../../services/api';
-import { useAuth } from '../../../../context/AuthContext.jsx';
-import ReusableTable from '../../../components/ReusableTable';
-import Modal from '../../../../components/ui/modals';
-import { formatCurrency } from '../../../../utils/formatters';
+import { getContratoById, createPago, updatePago, deletePago, descargarEstadoDeCuentaPDF, descargarEstadoDeCuentaExcel } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import Modal from '@/components/ui/modals';
+import { formatCurrency } from '@/utils/formatters';
 import { SquarePen, Trash, FileDown, Download } from 'lucide-react';
-import Loader from '../../../components/loaders/Loader';
-import MetodoPagoSelect from '../../../../components/ui/MetodoPagoSelect';
+import Loader from '@/components/loaders/Spinner';
+import MetodoPagoSelect from '@/components/ui/MetodoPagoSelect';
 
 // Componente para las tarjetas de resumen
 const InfoCard = ({ title, value, isCurrency = false, currencySymbol = 'USD', color = 'text-gray-900 dark:text-white' }) => (

--- a/frontend/luximia_erp_ui/app/(operaciones)/contratos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/contratos/page.jsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { getContratos } from '../../../services/api';
+import { getContratos } from '@/services/api';
 
 export default function ContratosPage() {
     const [contratos, setContratos] = useState([]);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/bancos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/bancos/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarBancos } from '../../../services/api';
+import { importarBancos } from '@/services/api';
 
 export default function ImportarBancosPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/clientes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/clientes/page.jsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import { importarClientes } from '../../../services/api';
+import { importarClientes } from '@/services/api';
 import Link from 'next/link';
 
 export default function ImportarClientesPage() {

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/contratos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/contratos/page.jsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarContratos } from '../../../services/api';
+import { importarContratos } from '@/services/api';
 
 export default function ImportarContratosPage() {
     const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/departamentos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/departamentos/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarDepartamentos } from '../../../services/api';
+import { importarDepartamentos } from '@/services/api';
 
 export default function ImportarDepartamentosPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/empleados/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/empleados/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarEmpleados } from '../../../services/api';
+import { importarEmpleados } from '@/services/api';
 
 export default function ImportarEmpleadosPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/esquemas-comision/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/esquemas-comision/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarEsquemasComision } from '../../../services/api';
+import { importarEsquemasComision } from '@/services/api';
 
 export default function ImportarEsquemasComisionPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/formas-pago/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/formas-pago/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarFormasPago } from '../../../services/api';
+import { importarFormasPago } from '@/services/api';
 
 export default function ImportarFormasPagoPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/monedas/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/monedas/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarMonedas } from '../../../services/api';
+import { importarMonedas } from '@/services/api';
 
 export default function ImportarMonedasPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/page.jsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import { importarDatosMasivos } from '../../services/api';
+import { importarDatosMasivos } from '@/services/api';
 
 export default function ImportarPage() {
     const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/pagos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/pagos/page.jsx
@@ -3,7 +3,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 // ### CAMBIO: Importamos la función correcta ###
-import { importarPagosHistoricos } from '../../../services/api';
+import { importarPagosHistoricos } from '@/services/api';
 import Link from 'next/link';
 
 // ### CAMBIO: Renombramos el componente ###

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/planes-pago/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/planes-pago/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarPlanesPago } from '../../../services/api';
+import { importarPlanesPago } from '@/services/api';
 
 export default function ImportarPlanesPagoPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/presupuestos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/presupuestos/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarPresupuestos } from '../../../services/api';
+import { importarPresupuestos } from '@/services/api';
 
 export default function ImportarPresupuestosPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/proyectos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/proyectos/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarProyectos } from '../../../services/api';
+import { importarProyectos } from '@/services/api';
 
 export default function ImportarProyectosPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/puestos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/puestos/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarPuestos } from '../../../services/api';
+import { importarPuestos } from '@/services/api';
 
 export default function ImportarPuestosPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/tipos-cambio/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/tipos-cambio/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarTiposCambio } from '../../../services/api';
+import { importarTiposCambio } from '@/services/api';
 
 export default function ImportarTiposCambioPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/upes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/upes/page.jsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarUPEs } from '../../../services/api';
+import { importarUPEs } from '@/services/api';
 
 export default function ImportarUPEsPage() {
     const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/vendedores/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/vendedores/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { importarVendedores } from '../../../services/api';
+import { importarVendedores } from '@/services/api';
 
 export default function ImportarVendedoresPage() {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/pagos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/pagos/page.jsx
@@ -1,13 +1,13 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getPagos, createPago, getContratos, getMetodosPago } from '../../services/api';
-import { useAuth } from '../../context/AuthContext.jsx';
-import ReusableTable from '../../components/ReusableTable';
-import { useResponsivePageSize } from '../../hooks/useResponsivePageSize';
+import { getPagos, createPago, getContratos, getMetodosPago } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ReusableTable from '@/components/ui/tables/ReusableTable';
+import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
 import Link from 'next/link';
-import Loader from '../../components/loaders/Loader';
-import Modal from '../../components/ui/modals';
+import Loader from '@/components/loaders/Spinner';
+import Modal from '@/components/ui/modals';
 
 export default function PagosPage() {
     const { hasPermission } = useAuth();

--- a/frontend/luximia_erp_ui/app/(operaciones)/presupuestos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/presupuestos/page.jsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { getClientes, getProyectos, getUPEs, createPresupuesto, updatePresupuesto, getPresupuesto } from '../../../services/api';
+import { getClientes, getProyectos, getUPEs, createPresupuesto, updatePresupuesto, getPresupuesto } from '@/services/api';
 
 export default function PresupuestoFormPage() {
     const searchParams = useSearchParams();

--- a/frontend/luximia_erp_ui/app/(operaciones)/reportes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/reportes/page.jsx
@@ -1,9 +1,9 @@
 'use client';
 
 import React, { useState } from 'react';
-import { exportProyectosExcel, exportClientesExcel, exportUpesExcel, exportContratosExcel } from '../../services/api';
-import { useAuth } from '../../context/AuthContext.jsx';
-import ExportModal from '../../components/ExportModal';
+import { exportProyectosExcel, exportClientesExcel, exportUpesExcel, exportContratosExcel } from '@/services/api';
+import { useAuth } from '@/context/AuthContext';
+import ExportModal from '@/components/ui/modals/Export';
 import { Download } from 'lucide-react';
 
 const PROYECTO_COLUMNAS_EXPORT = [

--- a/frontend/luximia_erp_ui/app/page.jsx
+++ b/frontend/luximia_erp_ui/app/page.jsx
@@ -2,8 +2,8 @@
 'use client';
 
 import { useAuth } from '@/context/AuthContext';
-import DashboardPage from '@/dashboard/page';
-import HomePage from '@/home/page';
+import DashboardPage from '@/app/(main)/dashboard/page';
+import HomePage from '@/app/(main)/home/page';
 import { useEffect, useState } from 'react';
 import Overlay from '@/components/loaders/Overlay';
 

--- a/frontend/luximia_erp_ui/components/layout/Navbar.jsx
+++ b/frontend/luximia_erp_ui/components/layout/Navbar.jsx
@@ -3,9 +3,9 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
-import { useSidebar } from '../../context/SidebarContext';
-import { useAuth } from '../../context/AuthContext.jsx';
-import ThemeSwitcher from './ThemeSwitcher';
+import { useSidebar } from '@/context/SidebarContext';
+import { useAuth } from '@/context/AuthContext';
+import ThemeSwitcher from '@/components/layout/ThemeSwitcher';
 import { CircleUser, LogOut } from 'lucide-react';
 
 export default function Navbar() {

--- a/frontend/luximia_erp_ui/components/layout/Sidebar.jsx
+++ b/frontend/luximia_erp_ui/components/layout/Sidebar.jsx
@@ -2,11 +2,11 @@
 'use client';
 
 import Link from 'next/link';
-import { useAuth } from '../../context/AuthContext.jsx';
-import { useSidebar } from '../../context/SidebarContext.jsx';
+import { useAuth } from '@/context/AuthContext';
+import { useSidebar } from '@/context/SidebarContext';
 import { useState, useEffect, useRef } from 'react';
 import { usePathname } from 'next/navigation';
-import ThemeSwitcher from './ThemeSwitcher';
+import ThemeSwitcher from '@/components/layout/ThemeSwitcher';
 import {
     Home,
     Users,

--- a/frontend/luximia_erp_ui/components/loaders/Overlay.jsx
+++ b/frontend/luximia_erp_ui/components/loaders/Overlay.jsx
@@ -1,5 +1,5 @@
 //components/loaders/Overlay.jsx
-import Spinner from "./Spinner";
+import Spinner from '@/components/loaders/Spinner';
 
 export default function Overlay({ show = false, children = null }) {
     if (!show) return null;

--- a/frontend/luximia_erp_ui/components/loaders/index.jsx
+++ b/frontend/luximia_erp_ui/components/loaders/index.jsx
@@ -4,7 +4,7 @@
 // La sintaxis `export { default as Nombre }` renombra la exportación por defecto
 // para que pueda ser importada usando su nombre.
 
-export { default as Spinner } from './Spinner'; // Tu spinner principal
-export { default as Bars } from './Bars';
-export { default as Dots } from './Dots';
-export { default as Overlay } from './Overlay';
+export { default as Spinner } from '@/components/loaders/Spinner'; // Tu spinner principal
+export { default as Bars } from '@/components/loaders/Bars';
+export { default as Dots } from '@/components/loaders/Dots';
+export { default as Overlay } from '@/components/loaders/Overlay';

--- a/frontend/luximia_erp_ui/components/ui/modals/Confirmation.jsx
+++ b/frontend/luximia_erp_ui/components/ui/modals/Confirmation.jsx
@@ -1,7 +1,7 @@
 //components/ui/modals/Confirmation.jsx
 'use client';
 
-import Modal from '.';
+import Modal from '@/components/ui/modals';
 
 export default function ConfirmationModal({
     isOpen,

--- a/frontend/luximia_erp_ui/components/ui/modals/Export.jsx
+++ b/frontend/luximia_erp_ui/components/ui/modals/Export.jsx
@@ -1,6 +1,6 @@
 //components/ui/modals/Export.jsx
 import React from 'react';
-import Modal from '.';
+import Modal from '@/components/ui/modals';
 
 export default function ExportModal({ isOpen, onClose, columns, selectedColumns, onColumnChange, onDownload }) {
     return (

--- a/frontend/luximia_erp_ui/components/ui/modals/Form.jsx
+++ b/frontend/luximia_erp_ui/components/ui/modals/Form.jsx
@@ -1,7 +1,7 @@
 //components/ui/modals/Form.jsx
 'use client';
 
-import Modal from '.';
+import Modal from '@/components/ui/modals';
 
 // El FormModal ahora es capaz de renderizar grupos de checkboxes
 export default function FormModal({

--- a/frontend/luximia_erp_ui/components/ui/tables/ReusableTable.jsx
+++ b/frontend/luximia_erp_ui/components/ui/tables/ReusableTable.jsx
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
 import { Eye, SquarePen, Trash, XCircle } from 'lucide-react';
-import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from './shadcn-table-base';
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/tables/shadcn-table-base';
 import Overlay from '@/components/loaders/Overlay';
 
 export default function ReusableTable({ data, columns, actions = {}, search = true, filterFunction }) {


### PR DESCRIPTION
## Summary
- replace relative frontend imports with `@/` aliases
- correct component and utility paths after folder restructuring

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d148a79648332be9cf5463d6bb1c3