### PR TITLE
refactor(frontend): replace loader with overlay

### DIFF
--- a/frontend/luximia_erp_ui/app/(catalogos)/planes-pago/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/planes-pago/page.jsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/context/AuthContext';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
-import Loader from '@/components/loaders/Spinner';
+import Overlay from '@/components/loaders/Overlay';
 
 export default function PlanesPagoPage() {
     const { hasPermission } = useAuth();
@@ -143,7 +143,7 @@ export default function PlanesPagoPage() {
     }
 
     if (loading && !isPaginating) {
-        return <Loader className="p-8" />;
+        return <Overlay show />;
     }
 
     return (
@@ -158,11 +158,7 @@ export default function PlanesPagoPage() {
             </div>
             {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
             <div ref={ref} className="flex-grow min-h-0 relative">
-                {isPaginating && (
-                    <div className="absolute inset-0 bg-white/50 dark:bg-gray-900/50 flex items-center justify-center z-10">
-                        <Loader overlay={false} />
-                    </div>
-                )}
+                <Overlay show={isPaginating} />
                 <ReusableTable data={pageData.results} columns={columns} />
             </div>
             <div className="flex-shrink-0 flex justify-between items-center mt-4">

--- a/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/roles/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/roles/page.jsx
@@ -9,7 +9,7 @@ import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import { translatePermission, translateModel } from '@/utils/permissions';
-import Loader from '@/components/loaders/Spinner';
+import Overlay from '@/components/loaders/Overlay';
 
 // --- Constantes de Configuración ---
 
@@ -151,7 +151,7 @@ export default function RolesPage() {
         }
     };
 
-    if (loading) return <Loader className="p-8" />;
+    if (loading) return <Overlay show />;
 
     return (
         <div className="p-8 h-full flex flex-col">

--- a/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/usuarios/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/usuarios/page.jsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/context/AuthContext';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
-import Loader from '@/components/loaders/Spinner';
+import Overlay from '@/components/loaders/Overlay';
 
 const USUARIO_COLUMNAS_DISPLAY = [
     { header: 'Usuario', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.username}</span> },
@@ -144,7 +144,7 @@ export default function UsuariosPage() {
     };
 
 
-    if (loading) return <Loader className="p-8" />;
+    if (loading) return <Overlay show />;
 
     return (
         <div className="p-8">

--- a/frontend/luximia_erp_ui/app/(main)/dashboard/page.jsx
+++ b/frontend/luximia_erp_ui/app/(main)/dashboard/page.jsx
@@ -5,7 +5,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { getStrategicDashboardData, getAllProyectos } from '@/services/api';
 
 // Componentes de UI
-import Loader from '@/components/loaders/Spinner';
+import Overlay from '@/components/loaders/Overlay';
 import KpiCard from '@/components/ui/cards/Kpi';
 import VentasChart from '@/components/charts/Ventas';
 import FlujoCobranzaChart from '@/components/charts/FlujoCobranza';
@@ -68,17 +68,13 @@ export default function DashboardPage() {
 
 
   if (loading && !dashboardData) {
-    return <Loader className="p-8" />;
+    return <Overlay show />;
   }
 
   return (
     <div className="relative p-4 sm:p-6 md:p-8 bg-slate-50 dark:bg-slate-900 min-h-screen">
       {/* --- Overlay de Carga --- */}
-      {loading && (
-        <div className="absolute inset-0 bg-white/60 dark:bg-gray-900/60 flex items-center justify-center z-20">
-          <Loader size={80} />
-        </div>
-      )}
+      <Overlay show={loading} />
 
       {/* --- Encabezado y Filtros --- */}
       <div className="flex flex-col md:flex-row justify-between items-center gap-4 mb-8">

--- a/frontend/luximia_erp_ui/app/(operaciones)/contratos/[id]/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/contratos/[id]/page.jsx
@@ -9,7 +9,7 @@ import ReusableTable from '@/components/ui/tables/ReusableTable';
 import Modal from '@/components/ui/modals';
 import { formatCurrency } from '@/utils/formatters';
 import { SquarePen, Trash, FileDown, Download } from 'lucide-react';
-import Loader from '@/components/loaders/Spinner';
+import Overlay from '@/components/loaders/Overlay';
 import MetodoPagoSelect from '@/components/ui/MetodoPagoSelect';
 
 // Componente para las tarjetas de resumen
@@ -254,7 +254,7 @@ export default function ContratoDetallePage() {
         }
     ];
 
-    if (loading) return <Loader className="p-8" />;
+    if (loading) return <Overlay show />;
     if (error && !contrato) return <div className="p-8 text-red-500 bg-red-100 p-4 rounded-md">{error}</div>;
     if (!contrato) return <div className="p-8">No se encontró el contrato.</div>;
 

--- a/frontend/luximia_erp_ui/app/(operaciones)/pagos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/pagos/page.jsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/context/AuthContext';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
 import Link from 'next/link';
-import Loader from '@/components/loaders/Spinner';
+import Overlay from '@/components/loaders/Overlay';
 import Modal from '@/components/ui/modals';
 
 export default function PagosPage() {
@@ -112,7 +112,7 @@ export default function PagosPage() {
     }
 
     if (loading && !isPaginating) {
-        return <Loader className="p-8" />;
+        return <Overlay show />;
     }
 
     return (
@@ -125,11 +125,7 @@ export default function PagosPage() {
             </div>
             {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
             <div ref={ref} className="flex-grow min-h-0 relative">
-                {isPaginating && (
-                    <div className="absolute inset-0 bg-white/50 dark:bg-gray-900/50 flex items-center justify-center z-10">
-                        <Loader overlay={false} />
-                    </div>
-                )}
+                <Overlay show={isPaginating} />
                 <ReusableTable data={pageData.results} columns={columns} />
             </div>
             <div className="flex-shrink-0 flex justify-between items-center mt-4">


### PR DESCRIPTION
## Summary
- replace Loader imports with Overlay spinner across frontend pages
- render overlay during loading states and pagination

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d18119f7883328109dbf70e38127c