### PR TITLE
Allow superusers to access admin views

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -24,9 +24,11 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class PermissionSerializer(serializers.ModelSerializer):
+    content_type__model = serializers.CharField(source="content_type.model", read_only=True)
+
     class Meta:
         model = Permission
-        fields = ["id", "name", "codename", "content_type"]
+        fields = ["id", "name", "codename", "content_type__model"]
 
 
 class GroupSerializer(serializers.ModelSerializer):

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -65,6 +65,14 @@ from .serializers import (
 
 logger = logging.getLogger(__name__)
 
+
+class IsStaffOrSuperuser(permissions.BasePermission):
+    """Permite acceso a usuarios con is_staff o is_superuser."""
+
+    def has_permission(self, request, view):
+        user = request.user
+        return bool(user and (user.is_staff or user.is_superuser))
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -131,7 +139,7 @@ def _get_jwt_for_user(user) -> dict:
 # Vistas de usuarios
 # ---------------------------------------------------------------------------
 class InviteUserView(APIView):
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsStaffOrSuperuser]
 
     def _send_invite(self, user):
         """Función interna para generar y enviar el token de invitación."""
@@ -208,7 +216,7 @@ class UserDetailView(generics.RetrieveUpdateDestroyAPIView):
     """
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsStaffOrSuperuser]
 
     def perform_destroy(self, instance):
         """Realiza el soft delete en lugar del borrado permanente."""
@@ -221,7 +229,7 @@ class HardDeleteUserView(APIView):
     Elimina un usuario de forma permanente.
     Solo accesible para superusuarios.
     """
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsStaffOrSuperuser]
 
     def delete(self, request, pk, format=None):
         try:
@@ -240,21 +248,21 @@ class GroupListView(generics.ListCreateAPIView):
     # Agrega .order_by('name') o .order_by('id') al queryset
     queryset = Group.objects.all().order_by('name')
     serializer_class = GroupSerializer
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsStaffOrSuperuser]
 
 
 class GroupDetailView(generics.RetrieveUpdateDestroyAPIView):
     """Recupera, actualiza y elimina un grupo específico."""
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsStaffOrSuperuser]
 
 
 class PermissionListView(generics.ListAPIView):
     """Lista todos los permisos disponibles."""
     queryset = Permission.objects.all()
     serializer_class = PermissionSerializer
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsStaffOrSuperuser]
 
 
 


### PR DESCRIPTION
## Summary
- let superusers access user and role endpoints even if `is_staff` is false
- include permission model names for frontend grouping

## Testing
- `DATABASE_URL=sqlite://:memory: SECRET_KEY=test python manage.py test` *(fails: Unknown command 'crear_superusuario_inicial')*


------
https://chatgpt.com/codex/tasks/task_e_689f62f7b478833296fdb39b5032713b