### PR TITLE
fix: handle paginated user and group lists

### DIFF
--- a/frontend/luximia_erp_ui/app/(catalogos)/empleados/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/empleados/page.jsx
@@ -58,9 +58,20 @@ export default function EmpleadosPage() {
                 getDepartamentos(),
                 getPuestos(),
             ]);
-            setUsers(Array.isArray(usersRes.data) ? usersRes.data : []);
-            setDepartamentos(Array.isArray(deptRes.data) ? deptRes.data : []);
-            setPuestos(Array.isArray(puestoRes.data) ? puestoRes.data : []);
+
+            const usersData = Array.isArray(usersRes.data)
+                ? usersRes.data
+                : usersRes.data?.results || [];
+            const deptData = Array.isArray(deptRes.data)
+                ? deptRes.data
+                : deptRes.data?.results || [];
+            const puestoData = Array.isArray(puestoRes.data)
+                ? puestoRes.data
+                : puestoRes.data?.results || [];
+
+            setUsers(usersData);
+            setDepartamentos(deptData);
+            setPuestos(puestoData);
         } catch (err) {
             setError('No se pudieron cargar los catálogos.');
         }

--- a/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/usuarios/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/usuarios/page.jsx
@@ -64,8 +64,16 @@ export default function UsuariosPage() {
             // Lógica corregida: Llama a getInactiveUsers() si se ha pedido, de lo contrario llama a getUsers() para traer a todos.
             const usersPromise = showInactive ? getInactiveUsers() : getUsers();
             const [usersRes, groupsRes] = await Promise.all([usersPromise, getGroups()]);
-            setUsers(usersRes.data);
-            setGroups(groupsRes.data);
+
+            const usersData = Array.isArray(usersRes.data)
+                ? usersRes.data
+                : usersRes.data?.results || [];
+            const groupsData = Array.isArray(groupsRes.data)
+                ? groupsRes.data
+                : groupsRes.data?.results || [];
+
+            setUsers(usersData);
+            setGroups(groupsData);
         } catch (err) {
             setError('No se pudieron cargar los datos.');
             console.error(err);


### PR DESCRIPTION
## Summary
- handle pagination when fetching users and groups so tables render correctly
- normalize catalog option loading to parse paginated responses

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 python manage.py test` *(fails: 'sslmode' invalid keyword argument for Connection())*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a75e072ed48332b2544d00e63f4474