### PR TITLE
Disable pagination for role and permission listings

### DIFF
--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -267,6 +267,8 @@ class GroupListView(generics.ListCreateAPIView):
     queryset = Group.objects.all().order_by("name")
     serializer_class = GroupSerializer
     permission_classes = [IsStaffOrSuperuser]
+    # La lista de roles es corta, se devuelve completa sin paginación
+    pagination_class = None
 
 
 class GroupDetailView(generics.RetrieveUpdateDestroyAPIView):
@@ -283,6 +285,8 @@ class PermissionListView(generics.ListAPIView):
     queryset = Permission.objects.all()
     serializer_class = PermissionSerializer
     permission_classes = [IsStaffOrSuperuser]
+    # Se necesita la lista completa de permisos para construir formularios
+    pagination_class = None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Return full role list in `GroupListView`
- Return full permission list in `PermissionListView`

## Testing
- `DATABASE_URL=sqlite://:memory: SECRET_KEY=testing python manage.py test` *(fails: Unknown command 'crear_superusuario_inicial'; status 301 in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a7652bde9083328c88726d1ad1328d