### PR TITLE
fix theme switcher configuration

### DIFF
--- a/frontend/luximia_erp_ui/components/layout/ThemeSwitcher.jsx
+++ b/frontend/luximia_erp_ui/components/layout/ThemeSwitcher.jsx
@@ -6,12 +6,12 @@ import { Sun, Moon, Monitor } from 'lucide-react';
 import { useState, useEffect } from 'react';
 
 export default function ThemeSwitcher({ className }) {
-    const { theme, setTheme } = useTheme();
+    const { theme, resolvedTheme, setTheme } = useTheme();
     const [mounted, setMounted] = useState(false);
 
     useEffect(() => setMounted(true), []);
 
-    // Esto evita que el ícono incorrecto se muestre en el servidor
+    // Evita mostrar un ícono incorrecto durante la renderización en el servidor
     if (!mounted) {
         return (
             <button className={`${className || 'w-full px-4 py-2 text-sm'} flex items-center`}>
@@ -22,18 +22,24 @@ export default function ThemeSwitcher({ className }) {
     }
 
     const cycleTheme = () => {
-        if (theme === 'light') setTheme('dark');
-        else if (theme === 'dark') setTheme('system');
-        else setTheme('light');
+        if (theme === 'system') {
+            setTheme(resolvedTheme === 'light' ? 'dark' : 'light');
+        } else if (theme === 'light') {
+            setTheme('dark');
+        } else if (theme === 'dark') {
+            setTheme('system');
+        }
     };
 
-    const icon = theme === 'light'
-        ? <Sun className="h-5 w-5 text-yellow-500" />
-        : theme === 'dark'
-            ? <Moon className="h-5 w-5 text-blue-500" />
-            : <Monitor className="h-5 w-5 text-gray-700 dark:text-gray-300" />;
+    const current = theme === 'system' ? resolvedTheme : theme;
+    const icon =
+        theme === 'system'
+            ? <Monitor className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+            : current === 'light'
+                ? <Sun className="h-5 w-5 text-yellow-500" />
+                : <Moon className="h-5 w-5 text-blue-500" />;
 
-    const label = theme === 'light' ? 'Claro' : theme === 'dark' ? 'Oscuro' : 'Auto';
+    const label = theme === 'system' ? 'Auto' : current === 'light' ? 'Claro' : 'Oscuro';
 
     return (
         <button
@@ -41,7 +47,7 @@ export default function ThemeSwitcher({ className }) {
             className={`${className || 'w-full px-4 py-2 text-sm'} flex items-center`}
             title="Cambiar tema"
         >
-            <span className="transition-transform duration-300" key={theme}>
+            <span className="transition-transform duration-300" key={current}>
                 {icon}
             </span>
             <span className="ml-2">{label}</span>


### PR DESCRIPTION
## Summary
- improve ThemeSwitcher to use resolved theme state
- ensure manual theme cycle works reliably

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build` *(warn: Attempted import error: 'getTiposCambio' is not exported from '@/services/api'; Attempted import error: 'importarContratos' is not exported from '@/services/api'; Attempted import error: 'importarPagosHistoricos' is not exported from '@/services/api')*

------
https://chatgpt.com/codex/tasks/task_e_68a76c3115c083328c30677cec56d18b