### PR TITLE
feat: manage passkey and TOTP from user settings

### DIFF
--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -12,8 +12,11 @@ from .views import (
     EnrollmentValidationView,
     PasskeyRegisterChallengeView,
     PasskeyRegisterView,
+    PasskeyCredentialView,
     TOTPSetupView,
     TOTPVerifyView,
+    TOTPResetView,
+    TOTPResetVerifyView,
     StartLoginView,
     PasskeyLoginChallengeView,
     PasskeyLoginView,
@@ -39,8 +42,11 @@ urlpatterns = [
     path("enrollment/validate/", EnrollmentValidationView.as_view(), name="enrollment-validate"),
     path("passkey/register/challenge/", PasskeyRegisterChallengeView.as_view(), name="passkey-register-challenge"),
     path("passkey/register/", PasskeyRegisterView.as_view(), name="passkey-register"),
+    path("passkey/credentials/", PasskeyCredentialView.as_view(), name="passkey-credentials"),
     path("totp/setup/", TOTPSetupView.as_view(), name="totp-setup"),
     path("totp/verify/", TOTPVerifyView.as_view(), name="totp-verify"),
+    path("totp/reset/", TOTPResetView.as_view(), name="totp-reset"),
+    path("totp/reset/verify/", TOTPResetVerifyView.as_view(), name="totp-reset-verify"),
 
     # --- Login (alineado al front) ---
     path("login/start/", StartLoginView.as_view(), name="login-start"),

--- a/frontend/luximia_erp_ui/app/(configuraciones)/ajustes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/ajustes/page.jsx
@@ -2,26 +2,42 @@
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { useAuth } from '@/context/AuthContext';
-import { getUser, updateUser } from '@/services/api';
+import apiClient, {
+    getUser,
+    updateUser,
+    listPasskeyCredentials,
+    resetPasskeys,
+    startTotpReset,
+    verifyTotpReset,
+} from '@/services/api';
+import { startRegistration } from '@simplewebauthn/browser';
+import QRCode from 'react-qr-code';
 
 export default function AjustesPage() {
     const { user } = useAuth();
     const [firstName, setFirstName] = useState('');
     const [lastName, setLastName] = useState('');
     const [email, setEmail] = useState('');
-    const [password, setPassword] = useState('');
-    const [confirmPassword, setConfirmPassword] = useState('');
     const [profileImage, setProfileImage] = useState(null);
     const [message, setMessage] = useState('');
+    const [passkeys, setPasskeys] = useState([]);
+    const [hasTotp, setHasTotp] = useState(false);
+    const [totpUri, setTotpUri] = useState('');
+    const [totpCode, setTotpCode] = useState('');
 
     useEffect(() => {
         if (user) {
             const storedImage = localStorage.getItem('profileImage');
             if (storedImage) setProfileImage(storedImage);
-            getUser(user.user_id).then(res => {
+            getUser(user.user_id).then(async res => {
                 setFirstName(res.data.first_name || '');
                 setLastName(res.data.last_name || '');
                 setEmail(res.data.email || '');
+                setHasTotp(res.data.has_totp);
+                if (res.data.has_passkey) {
+                    const creds = await listPasskeyCredentials();
+                    setPasskeys(creds.data.credentials || []);
+                }
             });
         }
     }, [user]);
@@ -43,26 +59,65 @@ export default function AjustesPage() {
         localStorage.removeItem('profileImage');
     };
 
+    const handleRegisterPasskey = async () => {
+        setMessage('');
+        try {
+            const { data: options } = await apiClient.get('/users/passkey/register/challenge/');
+            const registration = await startRegistration({ optionsJSON: options });
+            await apiClient.post('/users/passkey/register/', registration);
+            const { data } = await listPasskeyCredentials();
+            setPasskeys(data.credentials || []);
+            setMessage('Passkey registrada');
+        } catch {
+            setMessage('Error al registrar Passkey');
+        }
+    };
+
+    const handleReplacePasskey = async () => {
+        try {
+            await resetPasskeys();
+            await handleRegisterPasskey();
+        } catch {
+            setMessage('Error al reemplazar Passkey');
+        }
+    };
+
+    const startTotpSetup = async () => {
+        setMessage('');
+        try {
+            const { data } = await startTotpReset();
+            setTotpUri(data.otpauth_uri);
+            setTotpCode('');
+        } catch {
+            setMessage('Error al iniciar TOTP');
+        }
+    };
+
+    const handleVerifyTotp = async (e) => {
+        e.preventDefault();
+        try {
+            await verifyTotpReset(totpCode);
+            setHasTotp(true);
+            setTotpUri('');
+            setTotpCode('');
+            setMessage('TOTP verificado');
+        } catch {
+            setMessage('Código TOTP inválido');
+        }
+    };
+
     const handleSubmit = async (e) => {
         e.preventDefault();
         setMessage('');
         if (!user) return;
-        if (password && password !== confirmPassword) {
-            setMessage('Las contraseñas no coinciden');
-            return;
-        }
         try {
-            const payload = {
+            await updateUser(user.user_id, {
                 username: user.username,
                 first_name: firstName,
                 last_name: lastName,
-                email
-            };
-            if (password) payload.password = password;
-            await updateUser(user.user_id, payload);
+                email,
+            });
             setMessage('Datos actualizados');
-            setPassword('');
-            setConfirmPassword('');
         } catch (err) {
             setMessage('Error al actualizar');
         }
@@ -71,6 +126,7 @@ export default function AjustesPage() {
     return (
         <div className="max-w-xl mx-auto p-4 space-y-4">
             <h1 className="text-xl font-bold">Ajustes de Usuario</h1>
+            {message && <div className="text-center text-sm text-red-500">{message}</div>}
             <form onSubmit={handleSubmit} className="space-y-4">
                 <div className="flex items-center space-x-4">
                     <div className="relative w-24 h-24">
@@ -113,30 +169,61 @@ export default function AjustesPage() {
                         />
                     </div>
                 </div>
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <div>
-                        <label className="text-sm">Nueva contraseña</label>
-                        <input
-                            type="password"
-                            className="w-full p-2 border rounded-md bg-white dark:bg-gray-800"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label className="text-sm">Confirmar contraseña</label>
-                        <input
-                            type="password"
-                            className="w-full p-2 border rounded-md bg-white dark:bg-gray-800"
-                            value={confirmPassword}
-                            onChange={(e) => setConfirmPassword(e.target.value)}
-                        />
-                    </div>
-                </div>
-                {message && <div className="text-center text-sm text-red-500">{message}</div>}
                 <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-md">Guardar cambios</button>
             </form>
+            <div className="space-y-6">
+                <div>
+                    <h2 className="text-lg font-semibold">Passkey</h2>
+                    {passkeys.length > 0 ? (
+                        <ul className="list-disc ml-6">
+                            {passkeys.map((p, i) => (
+                                <li key={i}>{p.id.slice(0, 10)}...</li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p>No hay passkeys registradas</p>
+                    )}
+                    <div className="flex gap-2 mt-2">
+                        <button type="button" onClick={handleRegisterPasskey} className="px-3 py-1 bg-blue-600 text-white rounded">Registrar</button>
+                        {passkeys.length > 0 && (
+                            <button type="button" onClick={handleReplacePasskey} className="px-3 py-1 bg-gray-600 text-white rounded">Reemplazar</button>
+                        )}
+                    </div>
+                </div>
+
+                <div>
+                    <h2 className="text-lg font-semibold">TOTP</h2>
+                    {hasTotp ? <p>Configurado</p> : <p>No configurado</p>}
+                    {totpUri ? (
+                        <form onSubmit={handleVerifyTotp} className="space-y-2 mt-2">
+                            <div className="p-2 bg-white inline-block"><QRCode value={totpUri} /></div>
+                            <input
+                                type="text"
+                                value={totpCode}
+                                onChange={(e) => setTotpCode(e.target.value)}
+                                maxLength={6}
+                                className="border p-2 w-full text-center rounded-md bg-white dark:bg-gray-800"
+                                placeholder="123456"
+                            />
+                            <button
+                                type="submit"
+                                disabled={totpCode.length !== 6}
+                                className="px-3 py-1 bg-green-600 text-white rounded w-full"
+                            >
+                                Verificar
+                            </button>
+                        </form>
+                    ) : (
+                        <button
+                            type="button"
+                            onClick={startTotpSetup}
+                            className="mt-2 px-3 py-1 bg-blue-600 text-white rounded"
+                        >
+                            {hasTotp ? 'Reconfigurar TOTP' : 'Configurar TOTP'}
+                        </button>
+                    )}
+                </div>
+            </div>
         </div>
     );
 }

--- a/frontend/luximia_erp_ui/services/api.js
+++ b/frontend/luximia_erp_ui/services/api.js
@@ -87,6 +87,10 @@ export const resendInvite = (userId) => apiClient.post(`/users/${userId}/resend-
 export const getUser = (id) => apiClient.get(`/users/${id}/`);
 export const getUsers = () => apiClient.get('/users/');
 export const getInactiveUsers = () => apiClient.get('/users/?is_active=False');
+export const listPasskeyCredentials = () => apiClient.get('/users/passkey/credentials/');
+export const resetPasskeys = () => apiClient.delete('/users/passkey/credentials/');
+export const startTotpReset = () => apiClient.post('/users/totp/reset/');
+export const verifyTotpReset = (code) => apiClient.post('/users/totp/reset/verify/', { code });
 
 // ===================== Grupos/Roles =====================
 export const getGroups = () => apiClient.get('/users/groups/');


### PR DESCRIPTION
## Summary
- expose API endpoints to list/reset passkeys and renew TOTP secrets
- replace password section with Passkey and TOTP management in settings
- add frontend helpers for passkey and TOTP management

## Testing
- `python manage.py test` *(fails: SECRET_KEY setting must not be empty)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7941688308332a99635e589c007e1