### PR TITLE
feat: smooth page transitions to avoid flicker

### DIFF
--- a/frontend/luximia_erp_ui/app/globals.css
+++ b/frontend/luximia_erp_ui/app/globals.css
@@ -28,3 +28,19 @@
 .dark ::-webkit-scrollbar-thumb:hover {
   background-color: #718096;
 }
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.page-transition {
+  animation: fadeIn 0.3s ease-in-out;
+}

--- a/frontend/luximia_erp_ui/components/layout/AppContent.jsx
+++ b/frontend/luximia_erp_ui/components/layout/AppContent.jsx
@@ -58,7 +58,7 @@ export default function AppContent({ children }) {
         <div className="min-h-screen">
             <Sidebar />
             <main className={`transition-all duration-300 ease-in-out bg-gray-100 dark:bg-gray-900 ${isOpen ? 'lg:ml-64' : 'lg:ml-20'} p-4`}>
-                <div>
+                <div key={pathname} className="page-transition">
                     {children}
                 </div>
                 {hasPermission('cxc.can_use_ai') && <ChatInteligente />}


### PR DESCRIPTION
## Summary
- animate route changes with fade-in wrapper to reduce flicker
- add global smooth scroll and color transitions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8a23be97c83328f6c60f6f07ec7d9