### PR TITLE
Organiza enlaces del sidebar en categorías

### DIFF
--- a/frontend/luximia_erp_ui/components/layout/Sidebar.jsx
+++ b/frontend/luximia_erp_ui/components/layout/Sidebar.jsx
@@ -161,7 +161,12 @@ export default function Sidebar() {
                             </Link>
                         </li>
 
-                        {/* CRUDs visibles por permisos */}
+                        {/* Catálogos */}
+                        {isOpen && (
+                            <li className="pt-2 px-2 text-xs font-semibold uppercase text-gray-500">
+                                Catálogos
+                            </li>
+                        )}
                         {hasPermission('cxc.view_cliente') && (
                             <li>
                                 <Link href="/clientes" className={getLinkClass('/clientes')}>
@@ -249,6 +254,13 @@ export default function Sidebar() {
                                     <FileText className="h-5 w-5" />
                                     {isOpen && <span className="ml-2">Contratos</span>}
                                 </Link>
+                            </li>
+                        )}
+
+                        {/* Finanzas */}
+                        {isOpen && (
+                            <li className="pt-2 px-2 text-xs font-semibold uppercase text-gray-500">
+                                Finanzas
                             </li>
                         )}
 


### PR DESCRIPTION
## Summary
- Agrupa los enlaces principales del sidebar en secciones "Catálogos" y "Finanzas" para facilitar la navegación

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8a3df805c833288a330ced516a9b7