### PR TITLE
Remove passkey and TOTP provider prompts

### DIFF
--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -405,12 +405,8 @@ class PasskeyRegisterView(APIView):
             )
 
         try:
-            # Extraemos proveedor si viene en la petición
-            payload = request.data.copy()
-            provider = payload.pop("provider", None)
-
             # ✅ convertir JSON del navegador a RegistrationCredential (dataclass)
-            credential = parse_registration_credential_json(payload)
+            credential = parse_registration_credential_json(request.data)
 
             verification = verify_registration_response(
                 credential=credential,
@@ -434,10 +430,6 @@ class PasskeyRegisterView(APIView):
                 .rstrip("="),
                 "sign_count": int(sign_count) if sign_count is not None else 0,
             }
-
-            if provider:
-                new_credential["provider"] = provider
-                user.passkey_provider = provider
 
             creds = user.passkey_credentials or []
             creds.append(new_credential)
@@ -511,9 +503,6 @@ class TOTPVerifyView(APIView):
         # Aquí está la lógica corregida
         if user.passkey_credentials and user.totp_secret:
             user.is_active = True
-        provider = request.data.get("provider")
-        if provider:
-            user.totp_provider = provider
         user.save()
 
         request.session.pop("enrollment_user_id", None)
@@ -573,9 +562,6 @@ class TOTPResetVerifyView(APIView):
             return Response(
                 {"detail": "Código inválido"}, status=status.HTTP_400_BAD_REQUEST
             )
-        provider = request.data.get("provider")
-        if provider:
-            request.user.totp_provider = provider
         request.user.save()
         return Response({"detail": "TOTP verificado"})
 

--- a/frontend/luximia_erp_ui/app/(autenticacion)/enroll/setup/page.jsx
+++ b/frontend/luximia_erp_ui/app/(autenticacion)/enroll/setup/page.jsx
@@ -26,7 +26,6 @@ function EnrollmentSetup() {
 
     const [qrUri, setQrUri] = useState('');
     const [totpCode, setTotpCode] = useState('');
-    const [totpProvider, setTotpProvider] = useState('');
 
     // --- Agregado: Referencia para el input de TOTP ---
     const totpInputRef = useRef(null);
@@ -37,8 +36,6 @@ function EnrollmentSetup() {
             try {
                 const { data } = await apiClient.post('/users/totp/setup/');
                 setQrUri(data.otpauth_uri);
-                const prov = prompt('App TOTP (ej. Authy)') || '';
-                setTotpProvider(prov);
 
                 // Mueve el foco al input una vez que el QR se ha cargado
                 if (totpInputRef.current) {
@@ -57,8 +54,7 @@ function EnrollmentSetup() {
             const { data: options } = await apiClient.get('/users/passkey/register/challenge/');
             if (!options?.challenge) throw new Error('Respuesta inválida del servidor.');
             const registrationResponse = await startRegistration({ optionsJSON: options });
-            const provider = prompt('Proveedor de la passkey (ej. Nordpass)') || '';
-            await apiClient.post('/users/passkey/register/', { ...registrationResponse, provider });
+            await apiClient.post('/users/passkey/register/', registrationResponse);
             setStep(2);
         } catch (err) {
             if (err?.response) {
@@ -78,7 +74,7 @@ function EnrollmentSetup() {
         setIsProcessing(true);
         setError(null);
         try {
-            const { data } = await apiClient.post('/users/totp/verify/', { code: totpCode, provider: totpProvider });
+            const { data } = await apiClient.post('/users/totp/verify/', { code: totpCode });
             console.log('[ENROLL] TOTP verificado. Respuesta:', data);
             router.replace('/login?enrolled=true');
         } catch (err) {

--- a/frontend/luximia_erp_ui/app/(configuraciones)/ajustes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/ajustes/page.jsx
@@ -68,11 +68,10 @@ export default function AjustesPage() {
         try {
             const { data: options } = await apiClient.get('/users/passkey/register/challenge/');
             const registration = await startRegistration({ optionsJSON: options });
-            const provider = prompt('Proveedor de la passkey (ej. Nordpass)') || '';
-            await apiClient.post('/users/passkey/register/', { ...registration, provider });
+            await apiClient.post('/users/passkey/register/', registration);
             const { data } = await listPasskeyCredentials();
             setPasskeys(data.credentials || []);
-            setPasskeyProvider(provider);
+            setPasskeyProvider('');
             setMessage('Passkey registrada');
         } catch {
             setMessage('Error al registrar Passkey');
@@ -104,11 +103,10 @@ export default function AjustesPage() {
     const startTotpSetup = async () => {
         setMessage('');
         try {
-            const provider = prompt('App TOTP (ej. Authy)') || '';
-            setTotpProvider(provider);
             const { data } = await startTotpReset();
             setTotpUri(data.otpauth_uri);
             setTotpCode('');
+            setTotpProvider('');
         } catch {
             setMessage('Error al iniciar TOTP');
         }
@@ -117,10 +115,11 @@ export default function AjustesPage() {
     const handleVerifyTotp = async (e) => {
         e.preventDefault();
         try {
-            await verifyTotpReset(totpCode, totpProvider);
+            await verifyTotpReset(totpCode);
             setHasTotp(true);
             setTotpUri('');
             setTotpCode('');
+            setTotpProvider('');
             setMessage('TOTP verificado');
         } catch {
             setMessage('Código TOTP inválido');

--- a/frontend/luximia_erp_ui/services/api.js
+++ b/frontend/luximia_erp_ui/services/api.js
@@ -90,8 +90,8 @@ export const getInactiveUsers = () => apiClient.get('/users/?is_active=False');
 export const listPasskeyCredentials = () => apiClient.get('/users/passkey/credentials/');
 export const resetPasskeys = () => apiClient.post('/users/passkey/reset/');
 export const startTotpReset = () => apiClient.post('/users/totp/reset/');
-export const verifyTotpReset = (code, provider) =>
-  apiClient.post('/users/totp/reset/verify/', { code, provider });
+export const verifyTotpReset = (code) =>
+  apiClient.post('/users/totp/reset/verify/', { code });
 
 // ===================== Grupos/Roles =====================
 export const getGroups = () => apiClient.get('/users/groups/');


### PR DESCRIPTION
## Summary
- stop capturing provider names during passkey and TOTP registration
- simplify enrollment and settings pages to no longer ask users for provider info
- adjust API helper for TOTP reset verification

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite://:memory: python manage.py test users` *(fails: FAILED (failures=3))*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba6e85dc8332abca4f9345760b00