### PR TITLE
Fix user settings display by including user id in auth context

### DIFF
--- a/frontend/luximia_erp_ui/context/AuthContext.jsx
+++ b/frontend/luximia_erp_ui/context/AuthContext.jsx
@@ -22,6 +22,7 @@ export const AuthProvider = ({ children }) => {
             setAuthTokens(tokens);
             // Corregido: Creamos un objeto de usuario explícito
             setUser({
+                user_id: decoded.user_id,
                 username: decoded.username,
                 email: decoded.email,
                 first_name: decoded.first_name, // <-- Extraemos y guardamos el nombre
@@ -63,6 +64,7 @@ export const AuthProvider = ({ children }) => {
                         setAuthTokens(parsed);
                         // Corregido: Guardamos el objeto de usuario completo
                         setUser({
+                            user_id: decoded.user_id,
                             username: decoded.username,
                             email: decoded.email,
                             first_name: decoded.first_name,


### PR DESCRIPTION
## Summary
- include user_id when setting user in auth context to enable profile page fetches

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e07eab0883328ba3e7924b988623