### PR TITLE
fix: improve collapsed sidebar icons and user footer

### DIFF
--- a/frontend/luximia_erp_ui/components/layout/Sidebar.jsx
+++ b/frontend/luximia_erp_ui/components/layout/Sidebar.jsx
@@ -223,7 +223,7 @@ export default function Sidebar() {
                                 </button>
 
                                 {isCatalogosOpen && (
-                                    <ul className="pl-4 mt-1 space-y-1">
+                                    <ul className={`${isCollapsed ? 'pl-0' : 'pl-4'} mt-1 space-y-1`}>
                                         {hasPermission('cxc.view_cliente') && (
                                             <li>
                                                 <Link href="/clientes" className={getLinkClass('/clientes', true)}>
@@ -324,7 +324,7 @@ export default function Sidebar() {
                                 </button>
 
                                 {isFinanzasOpen && (
-                                    <ul className="pl-4 mt-1 space-y-1">
+                                    <ul className={`${isCollapsed ? 'pl-0' : 'pl-4'} mt-1 space-y-1`}>
                                         {hasPermission('cxc.view_pago') && (
                                             <li>
                                                 <Link href="/pagos" className={getLinkClass('/pagos', true)}>
@@ -386,7 +386,7 @@ export default function Sidebar() {
                                 </button>
 
                                 {isAdminOpen && (
-                                    <ul className="pl-4 mt-1 space-y-1">
+                                    <ul className={`${isCollapsed ? 'pl-0' : 'pl-4'} mt-1 space-y-1`}>
                                         {canViewSettings && (
                                             <li>
                                                 <button
@@ -400,7 +400,7 @@ export default function Sidebar() {
                                                     {isOpen && <ChevronIcon isOpen={isGestionOpen} />}
                                                 </button>
                                                 {isGestionOpen && (
-                                                    <ul className="pl-4 mt-1 space-y-1">
+                                                    <ul className={`${isCollapsed ? 'pl-0' : 'pl-4'} mt-1 space-y-1`}>
                                                         {hasPermission('cxc.view_user') && (
                                                             <li>
                                                                 <Link
@@ -441,7 +441,7 @@ export default function Sidebar() {
                                                     {isOpen && <ChevronIcon isOpen={isHerramientasOpen} />}
                                                 </button>
                                                 {isHerramientasOpen && (
-                                                    <ul className="pl-4 mt-1 space-y-1">
+                                                    <ul className={`${isCollapsed ? 'pl-0' : 'pl-4'} mt-1 space-y-1`}>
                                                         {user?.is_superuser && (
                                                             <li>
                                                                 <Link href="/importar" className={getLinkClass('/importar', true)}>
@@ -587,7 +587,7 @@ export default function Sidebar() {
                                                     {isOpen && <ChevronIcon isOpen={isSeguridadOpen} />}
                                                 </button>
                                                 {isSeguridadOpen && (
-                                                    <ul className="pl-4 mt-1 space-y-1">
+                                                    <ul className={`${isCollapsed ? 'pl-0' : 'pl-4'} mt-1 space-y-1`}>
                                                         <li>
                                                             <Link href="/auditoria" className={getLinkClass('/auditoria', true)}>
                                                                 <FileSearch className="h-4 w-4" />
@@ -623,28 +623,33 @@ export default function Sidebar() {
                     <div className="space-y-1">
                         <button
                             onClick={handleUserToggle}
-                            className={`w-full flex items-center justify-between p-2 rounded-md hover:bg-blue-100 hover:text-blue-700 dark:hover:bg-blue-600 dark:hover:text-white ${isCollapsed ? 'justify-center' : ''
-                                }`}
+                            className={`w-full flex items-center justify-between p-2 rounded-md hover:bg-blue-100 hover:text-blue-700 dark:hover:bg-blue-600 dark:hover:text-white ${isCollapsed ? 'justify-center' : ''}`}
                         >
                             <div className={`flex items-center ${isCollapsed ? 'justify-center w-full' : ''}`}>
                                 <img src={user?.avatar || '/icon-luximia.png'} alt="Usuario" className="h-6 w-6 rounded-full" />
-                                <span className={`${textClasses} text-sm`}>{fullName}</span>
+                                {!isCollapsed && <span className={`${textClasses} text-sm`}>{fullName}</span>}
                             </div>
                             {isOpen && <ChevronIcon isOpen={isUserMenuOpen} />}
                         </button>
                         {isUserMenuOpen && (
                             <div className="absolute left-0 bottom-full w-full mb-2 bg-white dark:bg-gray-800 p-2 rounded-lg shadow-lg space-y-1 z-50">
-                                <ThemeSwitcher className="w-full p-2 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700" />
-                                <Link href="/ajustes" className="flex items-center p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700">
+                                <ThemeSwitcher
+                                    className={`w-full p-2 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 ${isCollapsed ? 'justify-center' : ''}`}
+                                    showLabel={!isCollapsed}
+                                />
+                                <Link
+                                    href="/ajustes"
+                                    className={`flex items-center p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 ${isCollapsed ? 'justify-center' : ''}`}
+                                >
                                     <Settings className="h-5 w-5" />
-                                    <span className={textClasses}>Ajustes</span>
+                                    {!isCollapsed && <span className={textClasses}>Ajustes</span>}
                                 </Link>
                                 <button
                                     onClick={logoutUser}
-                                    className="flex items-center w-full p-2 text-red-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700"
+                                    className={`flex items-center w-full p-2 text-red-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 ${isCollapsed ? 'justify-center' : ''}`}
                                 >
                                     <LogOut className="h-5 w-5" />
-                                    <span className={textClasses}>Cerrar sesión</span>
+                                    {!isCollapsed && <span className={textClasses}>Cerrar sesión</span>}
                                 </button>
                             </div>
                         )}

--- a/frontend/luximia_erp_ui/components/layout/ThemeSwitcher.jsx
+++ b/frontend/luximia_erp_ui/components/layout/ThemeSwitcher.jsx
@@ -5,7 +5,7 @@ import { useTheme } from 'next-themes';
 import { Sun, Moon, Monitor } from 'lucide-react';
 import { useState, useEffect } from 'react';
 
-export default function ThemeSwitcher({ className }) {
+export default function ThemeSwitcher({ className, showLabel = true }) {
     const { theme, resolvedTheme, setTheme } = useTheme();
     const [mounted, setMounted] = useState(false);
 
@@ -20,7 +20,7 @@ export default function ThemeSwitcher({ className }) {
         return (
             <button className={baseClasses}>
                 <Monitor className="h-5 w-5 text-gray-700 dark:text-gray-300" />
-                <span className="ml-2">Auto</span>
+                {showLabel && <span className="ml-2">Auto</span>}
             </button>
         );
     }
@@ -50,7 +50,7 @@ export default function ThemeSwitcher({ className }) {
             <span className="transition-transform duration-300" key={current}>
                 {icon}
             </span>
-            <span className="ml-2">{label}</span>
+            {showLabel && <span className="ml-2">{label}</span>}
         </button>
     );
 }


### PR DESCRIPTION
## Summary
- ensure user menu displays icons only when sidebar collapsed
- preserve icons in deeply nested submenus when sidebar is collapsed
- allow ThemeSwitcher to optionally hide its label

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca74e6a3c8332abb822f0d71ab3c8