### PR TITLE
feat: unify catalog actions

### DIFF
--- a/frontend/luximia_erp_ui/app/(catalogos)/bancos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/bancos/page.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import {
   getBancos,
   createBanco,
@@ -15,7 +16,7 @@ import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download } from 'lucide-react';
+import { Download, Upload } from 'lucide-react';
 
 const BANCO_COLUMNAS_DISPLAY = [
   { header: 'Clave', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.clave}</span> },
@@ -182,6 +183,23 @@ export default function BancosPage() {
                 {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
               </button>
             )}
+            {hasPermission('cxc.add_banco') && (
+              <button
+                onClick={handleCreateClick}
+                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
+              >
+                + Nuevo Banco
+              </button>
+            )}
+            {hasPermission('cxc.add_banco') && (
+              <Link
+                href="/importar/bancos"
+                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
+                title="Importar desde Excel"
+              >
+                <Upload className="h-6 w-6" />
+              </Link>
+            )}
             {hasPermission('cxc.view_banco') && (
               <button
                 onClick={() => setIsExportModalOpen(true)}
@@ -189,14 +207,6 @@ export default function BancosPage() {
                 title="Exportar a Excel"
               >
                 <Download className="h-6 w-6" />
-              </button>
-            )}
-            {hasPermission('cxc.add_banco') && (
-              <button
-                onClick={handleCreateClick}
-                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
-              >
-                + Nuevo Banco
               </button>
             )}
           </div>

--- a/frontend/luximia_erp_ui/app/(catalogos)/formas-pago/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/formas-pago/page.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import {
   getFormasPago,
   createFormaPago,
@@ -15,7 +16,7 @@ import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download } from 'lucide-react';
+import { Download, Upload } from 'lucide-react';
 
 const COLUMNS_DISPLAY = [
   { header: 'Enganche (%)', render: (row) => row.enganche },
@@ -190,6 +191,23 @@ export default function FormasPagoPage() {
                 {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
               </button>
             )}
+            {hasPermission('cxc.add_formapago') && (
+              <button
+                onClick={handleCreateClick}
+                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
+              >
+                + Nueva Forma
+              </button>
+            )}
+            {hasPermission('cxc.add_formapago') && (
+              <Link
+                href="/importar/formas-pago"
+                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
+                title="Importar desde Excel"
+              >
+                <Upload className="h-6 w-6" />
+              </Link>
+            )}
             {hasPermission('cxc.view_formapago') && (
               <button
                 onClick={() => setIsExportModalOpen(true)}
@@ -197,14 +215,6 @@ export default function FormasPagoPage() {
                 title="Exportar a Excel"
               >
                 <Download className="h-6 w-6" />
-              </button>
-            )}
-            {hasPermission('cxc.add_formapago') && (
-              <button
-                onClick={handleCreateClick}
-                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
-              >
-                + Nueva Forma
               </button>
             )}
           </div>

--- a/frontend/luximia_erp_ui/app/(catalogos)/monedas/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/monedas/page.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import {
   getMonedas,
   createMoneda,
@@ -15,7 +16,7 @@ import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download } from 'lucide-react';
+import { Download, Upload } from 'lucide-react';
 
 const MONEDA_COLUMNAS_DISPLAY = [
   { header: 'Código', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.codigo}</span> },
@@ -179,6 +180,23 @@ export default function MonedasPage() {
                 {showInactive ? 'Ver Activas' : 'Ver Inactivas'}
               </button>
             )}
+            {hasPermission('cxc.add_moneda') && (
+              <button
+                onClick={handleCreateClick}
+                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
+              >
+                + Nueva Moneda
+              </button>
+            )}
+            {hasPermission('cxc.add_moneda') && (
+              <Link
+                href="/importar/monedas"
+                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
+                title="Importar desde Excel"
+              >
+                <Upload className="h-6 w-6" />
+              </Link>
+            )}
             {hasPermission('cxc.view_moneda') && (
               <button
                 onClick={() => setIsExportModalOpen(true)}
@@ -186,14 +204,6 @@ export default function MonedasPage() {
                 title="Exportar a Excel"
               >
                 <Download className="h-6 w-6" />
-              </button>
-            )}
-            {hasPermission('cxc.add_moneda') && (
-              <button
-                onClick={handleCreateClick}
-                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
-              >
-                + Nueva Moneda
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary
- add import links and reorder action buttons across catalogs
- support export modal on departments, employees, schemes, and vendors

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68acae29c6688332aec28593b2d9e676