### PR TITLE
feat: add import/export for contracts

### DIFF
--- a/frontend/luximia_erp_ui/app/(operaciones)/contratos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/contratos/page.jsx
@@ -3,9 +3,10 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { getContratos } from '@/services/api';
+import { getContratos, exportContratosExcel } from '@/services/api';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import Loader from '@/components/loaders/Overlay'; // Usamos el Overlay para la carga
+import { Download, Upload } from 'lucide-react';
 
 export default function ContratosPage() {
     const [contratos, setContratos] = useState([]);
@@ -31,6 +32,27 @@ export default function ContratosPage() {
         },
     ];
 
+    const handleExport = async () => {
+        try {
+            const response = await exportContratosExcel(['id', 'abonos', 'saldo_pendiente']);
+            const blob = new Blob([
+                response.data,
+            ], {
+                type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            });
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'reporte_contratos.xlsx';
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            window.URL.revokeObjectURL(url);
+        } catch (err) {
+            console.error('No se pudo exportar el archivo.', err);
+        }
+    };
+
     useEffect(() => {
         async function fetchData() {
             try {
@@ -51,12 +73,29 @@ export default function ContratosPage() {
 
     return (
         <div className="p-8">
-            <h1 className="text-2xl font-bold mb-4 text-gray-800 dark:text-gray-200">Contratos</h1>
+            <div className="flex justify-between items-center mb-4">
+                <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-200">Contratos</h1>
+                <div className="flex items-center space-x-3">
+                    <Link
+                        href="/importar/contratos"
+                        className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg"
+                        title="Importar desde Excel"
+                    >
+                        <Upload className="h-5 w-5" />
+                    </Link>
+                    <button
+                        onClick={handleExport}
+                        className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg"
+                        title="Exportar a Excel"
+                    >
+                        <Download className="h-5 w-5" />
+                    </button>
+                </div>
+            </div>
             <ReusableTable
                 data={contratos}
                 columns={CONTRATOS_COLUMNAS}
-                search={true} // Habilitar la búsqueda
-            // Puedes añadir acciones como editar o eliminar si las implementas en esta página
+                search={true}
             />
         </div>
     );

--- a/frontend/luximia_erp_ui/services/api.js
+++ b/frontend/luximia_erp_ui/services/api.js
@@ -239,6 +239,10 @@ export const descargarEstadoDeCuentaExcel = (contratoId, planCols, pagoCols) =>
   apiClient.post(`/cxc/contratos/${contratoId}/descargar-excel/`, { plan_cols: planCols, pago_cols: pagoCols }, { responseType: 'blob' });
 export const exportContratosExcel = (columns) =>
   apiClient.post('/cxc/contratos/exportar-excel/', { columns }, { responseType: 'blob' });
+export const importarContratos = (formData) =>
+  apiClient.post('/cxc/contratos/importar-excel/', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
 
 // ===================== Pagos =====================
 export const createPago = (data) => apiClient.post('/cxc/pagos/', data);


### PR DESCRIPTION
## Summary
- expose `importarContratos` endpoint
- add Import/Export controls to contracts listing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acb8fe4a4083328083d4acb9913ea0