### PR TITLE
feat: add payments import and export

### DIFF
--- a/frontend/luximia_erp_ui/services/api.js
+++ b/frontend/luximia_erp_ui/services/api.js
@@ -244,6 +244,12 @@ export const exportContratosExcel = (columns) =>
 export const createPago = (data) => apiClient.post('/cxc/pagos/', data);
 export const updatePago = (id, data) => apiClient.patch(`/cxc/pagos/${id}/`, data);
 export const deletePago = (id) => apiClient.delete(`/cxc/pagos/${id}/`);
+export const exportPagosExcel = (columns) =>
+  apiClient.post('/cxc/pagos/exportar-excel/', { columns }, { responseType: 'blob' });
+export const importarPagosHistoricos = (formData) =>
+  apiClient.post('/cxc/pagos/importar-excel/', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
 
 // ===================== Métodos de Pago vs Formas de Pago =====================
 // Métodos de pago (catálogo "MetodoPago")


### PR DESCRIPTION
## Summary
- add API helpers for importing and exporting pagos
- provide import/export buttons on pagos list page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acb8ff81d08332b47b95bc7fafce42