### PR TITLE
feat(ui): add import/export actions for puestos

### DIFF
--- a/frontend/luximia_erp_ui/app/(catalogos)/puestos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/puestos/page.jsx
@@ -1,11 +1,23 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { getPuestos, createPuesto, updatePuesto, deletePuesto, getInactivePuestos, hardDeletePuesto, getAllDepartamentos } from '@/services/api';
+import Link from 'next/link';
+import {
+    getPuestos,
+    createPuesto,
+    updatePuesto,
+    deletePuesto,
+    getInactivePuestos,
+    hardDeletePuesto,
+    getAllDepartamentos,
+    exportPuestosExcel,
+} from '@/services/api';
 import { useAuth } from '@/context/AuthContext';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
+import ExportModal from '@/components/ui/modals/Export';
+import { Download, Upload } from 'lucide-react';
 
 const PUESTO_COLUMNAS_DISPLAY = [
     { header: 'Nombre', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.nombre}</span> },
@@ -17,6 +29,14 @@ const PUESTO_FORM_FIELDS_TEMPLATE = [
     { name: 'nombre', label: 'Nombre', required: true },
     { name: 'departamento', label: 'Departamento', type: 'select', options: [] },
     { name: 'descripcion', label: 'Descripción', type: 'textarea' },
+];
+
+const PUESTO_COLUMNAS_EXPORT = [
+    { id: 'id', label: 'ID' },
+    { id: 'nombre', label: 'Nombre' },
+    { id: 'departamento_nombre', label: 'Departamento' },
+    { id: 'descripcion', label: 'Descripción' },
+    { id: 'activo', label: 'Estado' },
 ];
 
 export default function PuestosPage() {
@@ -37,6 +57,13 @@ export default function PuestosPage() {
     const [loading, setLoading] = useState(true);
     const [isPaginating, setIsPaginating] = useState(false);
     const [showInactive, setShowInactive] = useState(false);
+    const [isExportModalOpen, setIsExportModalOpen] = useState(false);
+    const [selectedColumns, setSelectedColumns] = useState(() => {
+        const cols = {};
+        PUESTO_COLUMNAS_EXPORT.forEach(c => (cols[c.id] = true));
+        return cols;
+        
+    });
 
     const fetchDepartamentos = useCallback(async () => {
         try {
@@ -143,6 +170,30 @@ export default function PuestosPage() {
         }
     };
 
+    const handleColumnChange = (e) => {
+        const { name, checked } = e.target;
+        setSelectedColumns(prev => ({ ...prev, [name]: checked }));
+    };
+
+    const handleExport = async () => {
+        const columnsToExport = PUESTO_COLUMNAS_EXPORT.filter(c => selectedColumns[c.id]).map(c => c.id);
+        try {
+            const response = await exportPuestosExcel(columnsToExport);
+            const blob = new Blob([response.data], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'reporte_puestos.xlsx';
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            window.URL.revokeObjectURL(url);
+            setIsExportModalOpen(false);
+        } catch (err) {
+            setError('No se pudo exportar el archivo.');
+        }
+    };
+
     return (
         <div className="p-8 h-full flex flex-col">
             <div className="flex-shrink-0">
@@ -157,6 +208,24 @@ export default function PuestosPage() {
                         {hasPermission('cxc.add_puesto') && (
                             <button onClick={handleCreateClick} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">
                                 + Nuevo Puesto
+                            </button>
+                        )}
+                        {hasPermission('cxc.add_puesto') && (
+                            <Link
+                                href="/importar/puestos"
+                                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
+                                title="Importar desde Excel"
+                            >
+                                <Upload className="h-6 w-6" />
+                            </Link>
+                        )}
+                        {hasPermission('cxc.view_puesto') && (
+                            <button
+                                onClick={() => setIsExportModalOpen(true)}
+                                className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
+                                title="Exportar a Excel"
+                            >
+                                <Download className="h-6 w-6" />
                             </button>
                         )}
                     </div>
@@ -199,6 +268,14 @@ export default function PuestosPage() {
                 onClose={() => setIsConfirmModalOpen(false)}
                 onConfirm={handleConfirmDelete}
                 message="¿Seguro que deseas eliminar este puesto?"
+            />
+            <ExportModal
+                isOpen={isExportModalOpen}
+                onClose={() => setIsExportModalOpen(false)}
+                columns={PUESTO_COLUMNAS_EXPORT}
+                selectedColumns={selectedColumns}
+                onChange={handleColumnChange}
+                onExport={handleExport}
             />
         </div>
     );


### PR DESCRIPTION
## Summary
- replicate action bar from Vendedores for Puestos
- add Import and Export buttons with permission checks
- export puestos to Excel via `exportPuestosExcel`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acb8fa9fc88332a3206e3e28185493