### PR TITLE
feat: reorder payment action buttons

### DIFF
--- a/frontend/luximia_erp_ui/app/(operaciones)/pagos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/pagos/page.jsx
@@ -168,18 +168,29 @@ export default function PagosPage() {
                 <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Pagos Registrados</h1>
                 <div className="flex items-center space-x-3">
                     {hasPermission('cxc.add_pago') && (
-                        <Link href="/importar/pagos" className="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg">
-                            Importar
-                        </Link>
-                    )}
-                    {hasPermission('cxc.view_pago') && (
-                        <button onClick={handleExport} className="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg">
-                            Exportar
+                        <button
+                            onClick={handleCreateClick}
+                            className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg"
+                        >
+                            + Registrar Pago
                         </button>
                     )}
                     {hasPermission('cxc.add_pago') && (
-                        <button onClick={handleCreateClick} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">
-                            + Registrar Pago
+                        <Link
+                            href="/importar/pagos"
+                            className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg"
+                            title="Importar desde Excel"
+                        >
+                            <Upload className="h-6 w-6" />
+                        </Link>
+                    )}
+                    {hasPermission('cxc.view_pago') && (
+                        <button
+                            onClick={handleExport}
+                            className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg"
+                            title="Exportar a Excel"
+                        >
+                            <Download className="h-6 w-6" />
                         </button>
                     )}
                 </div>


### PR DESCRIPTION
## Summary
- reorder payment buttons and use icon buttons for import/export

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acd5cccde8833295920eab38f73808