### PR TITLE
Refactor action buttons into reusable icon component

### DIFF
--- a/frontend/luximia_erp_ui/app/(catalogos)/bancos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/bancos/page.jsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import {
   getBancos,
   createBanco,
@@ -16,7 +15,7 @@ import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const BANCO_COLUMNAS_DISPLAY = [
   { header: 'Clave', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.clave}</span> },
@@ -174,42 +173,17 @@ export default function BancosPage() {
       <div className="flex-shrink-0">
         <div className="flex justify-between items-center mb-10">
           <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Bancos</h1>
-          <div className="flex items-center space-x-3">
-            {hasPermission('cxc.can_view_inactive_records') && (
-              <button
-                onClick={() => setShowInactive(!showInactive)}
-                className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
-              >
-                {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-              </button>
-            )}
-            {hasPermission('cxc.add_banco') && (
-              <button
-                onClick={handleCreateClick}
-                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
-              >
-                + Nuevo Banco
-              </button>
-            )}
-            {hasPermission('cxc.add_banco') && (
-              <Link
-                href="/importar/bancos"
-                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                title="Importar desde Excel"
-              >
-                <Upload className="h-6 w-6" />
-              </Link>
-            )}
-            {hasPermission('cxc.view_banco') && (
-              <button
-                onClick={() => setIsExportModalOpen(true)}
-                className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                title="Exportar a Excel"
-              >
-                <Download className="h-6 w-6" />
-              </button>
-            )}
-          </div>
+          <ActionButtons
+            showInactive={showInactive}
+            onToggleInactive={() => setShowInactive(!showInactive)}
+            canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+            onCreate={handleCreateClick}
+            canCreate={hasPermission('cxc.add_banco')}
+            importHref="/importar/bancos"
+            canImport={hasPermission('cxc.add_banco')}
+            onExport={() => setIsExportModalOpen(true)}
+            canExport={hasPermission('cxc.view_banco')}
+          />
         </div>
         {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
       </div>

--- a/frontend/luximia_erp_ui/app/(catalogos)/clientes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/clientes/page.jsx
@@ -18,7 +18,7 @@ import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import ExportModal from '@/components/ui/modals/Export';
 import ImportModal from '@/components/ui/modals/Import';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 
 const CLIENTE_COLUMNAS_DISPLAY = [
@@ -206,37 +206,17 @@ export default function ClientesPage() {
         <div className="p-8 h-full flex flex-col">
             <div className="flex justify-between items-center mb-10">
                 <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Clientes</h1>
-                <div className="flex items-center space-x-3">
-                    {hasPermission('cxc.can_view_inactive_records') && (
-                        <button onClick={() => setShowInactive(!showInactive)} className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">
-                            {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-                        </button>
-                    )}
-                    {hasPermission('cxc.add_cliente') && (
-                        <>
-                            <button
-                                onClick={handleCreateClick}
-                                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg"
-                            >
-                                + Nuevo Cliente
-                            </button>
-                            <button
-                                onClick={() => setIsImportModalOpen(true)}
-                                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg"
-                                title="Importar desde Excel"
-                            >
-                                <Upload className="h-6 w-6" />
-                            </button>
-                        </>
-                    )}
-                    <button
-                        onClick={() => setIsExportModalOpen(true)}
-                        className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg"
-                        title="Exportar a Excel"
-                    >
-                        <Download className="h-6 w-6" />
-                    </button>
-                </div>
+                <ActionButtons
+                    showInactive={showInactive}
+                    onToggleInactive={() => setShowInactive(!showInactive)}
+                    canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+                    onCreate={handleCreateClick}
+                    canCreate={hasPermission('cxc.add_cliente')}
+                    onImport={() => setIsImportModalOpen(true)}
+                    canImport={hasPermission('cxc.add_cliente')}
+                    onExport={() => setIsExportModalOpen(true)}
+                    canExport
+                />
             </div>
 
             {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}

--- a/frontend/luximia_erp_ui/app/(catalogos)/departamentos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/departamentos/page.jsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import {
     getDepartamentos,
     createDepartamento,
@@ -16,7 +15,7 @@ import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const DEPARTAMENTO_COLUMNAS_DISPLAY = [
     { header: 'Nombre', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.nombre}</span> },
@@ -161,36 +160,17 @@ export default function DepartamentosPage() {
             <div className="flex-shrink-0">
                 <div className="flex justify-between items-center mb-10">
                     <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Departamentos</h1>
-                    <div className="flex items-center space-x-3">
-                        {hasPermission('cxc.can_view_inactive_records') && (
-                            <button onClick={() => setShowInactive(!showInactive)} className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">
-                                {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-                            </button>
-                        )}
-                        {hasPermission('cxc.add_departamento') && (
-                            <button onClick={handleCreateClick} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">
-                                + Nuevo Departamento
-                            </button>
-                        )}
-                        {hasPermission('cxc.add_departamento') && (
-                            <Link
-                                href="/importar/departamentos"
-                                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                                title="Importar desde Excel"
-                            >
-                                <Upload className="h-6 w-6" />
-                            </Link>
-                        )}
-                        {hasPermission('cxc.view_departamento') && (
-                            <button
-                                onClick={() => setIsExportModalOpen(true)}
-                                className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                                title="Exportar a Excel"
-                            >
-                                <Download className="h-6 w-6" />
-                            </button>
-                        )}
-                    </div>
+                    <ActionButtons
+                        showInactive={showInactive}
+                        onToggleInactive={() => setShowInactive(!showInactive)}
+                        canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+                        onCreate={handleCreateClick}
+                        canCreate={hasPermission('cxc.add_departamento')}
+                        importHref="/importar/departamentos"
+                        canImport={hasPermission('cxc.add_departamento')}
+                        onExport={() => setIsExportModalOpen(true)}
+                        canExport={hasPermission('cxc.view_departamento')}
+                    />
                 </div>
                 {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
             </div>

--- a/frontend/luximia_erp_ui/app/(catalogos)/empleados/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/empleados/page.jsx
@@ -2,7 +2,6 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import {
     getEmpleados,
     createEmpleado,
@@ -20,7 +19,7 @@ import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const EMPLEADO_COLUMNAS_DISPLAY = [
     { header: 'Usuario', render: (row) => row.user_username },
@@ -216,42 +215,17 @@ export default function EmpleadosPage() {
         <div className="p-8 h-full flex flex-col">
             <div className="flex justify-between items-center mb-10">
                 <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Empleados</h1>
-                <div className="flex items-center space-x-3">
-                    {hasPermission('cxc.can_view_inactive_records') && (
-                        <button
-                            onClick={() => setShowInactive(!showInactive)}
-                            className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg"
-                        >
-                            {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-                        </button>
-                    )}
-                    {hasPermission('cxc.add_empleado') && (
-                        <button
-                            onClick={handleCreateClick}
-                            className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg"
-                        >
-                            + Nuevo Empleado
-                        </button>
-                    )}
-                    {hasPermission('cxc.add_empleado') && (
-                        <Link
-                            href="/importar/empleados"
-                            className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                            title="Importar desde Excel"
-                        >
-                            <Upload className="h-6 w-6" />
-                        </Link>
-                    )}
-                    {hasPermission('cxc.view_empleado') && (
-                        <button
-                            onClick={() => setIsExportModalOpen(true)}
-                            className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                            title="Exportar a Excel"
-                        >
-                            <Download className="h-6 w-6" />
-                        </button>
-                    )}
-                </div>
+                <ActionButtons
+                    showInactive={showInactive}
+                    onToggleInactive={() => setShowInactive(!showInactive)}
+                    canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+                    onCreate={handleCreateClick}
+                    canCreate={hasPermission('cxc.add_empleado')}
+                    importHref="/importar/empleados"
+                    canImport={hasPermission('cxc.add_empleado')}
+                    onExport={() => setIsExportModalOpen(true)}
+                    canExport={hasPermission('cxc.view_empleado')}
+                />
             </div>
 
             {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}

--- a/frontend/luximia_erp_ui/app/(catalogos)/esquemas-comision/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/esquemas-comision/page.jsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import { getEsquemasComision, createEsquemaComision, updateEsquemaComision, deleteEsquemaComision, getInactiveEsquemasComision, hardDeleteEsquemaComision, exportEsquemasComisionExcel } from '@/services/api';
 import { useAuth } from '@/context/AuthContext';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
@@ -9,7 +8,7 @@ import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ExportModal from '@/components/ui/modals/Export';
 import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const ESQUEMA_COLUMNAS_DISPLAY = [
     { header: 'Esquema', render: (row) => <span className="text-gray-900 dark:text-white">{row.esquema}</span> },
@@ -176,36 +175,17 @@ export default function EsquemasComisionPage() {
             <div className="flex-shrink-0">
                 <div className="flex justify-between items-center mb-10">
                     <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Esquemas de Comisión</h1>
-                    <div className="flex items-center space-x-3">
-                        {hasPermission('cxc.can_view_inactive_records') && (
-                            <button onClick={() => setShowInactive(!showInactive)} className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">
-                                {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-                            </button>
-                        )}
-                        {hasPermission('cxc.add_esquemacomision') && (
-                            <button onClick={handleCreateClick} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">
-                                + Nuevo Esquema
-                            </button>
-                        )}
-                        {hasPermission('cxc.add_esquemacomision') && (
-                            <Link
-                                href="/importar/esquemas-comision"
-                                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                                title="Importar desde Excel"
-                            >
-                                <Upload className="h-6 w-6" />
-                            </Link>
-                        )}
-                        {hasPermission('cxc.view_esquemacomision') && (
-                            <button
-                                onClick={() => setIsExportModalOpen(true)}
-                                className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                                title="Exportar a Excel"
-                            >
-                                <Download className="h-6 w-6" />
-                            </button>
-                        )}
-                    </div>
+                    <ActionButtons
+                        showInactive={showInactive}
+                        onToggleInactive={() => setShowInactive(!showInactive)}
+                        canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+                        onCreate={handleCreateClick}
+                        canCreate={hasPermission('cxc.add_esquemacomision')}
+                        importHref="/importar/esquemas-comision"
+                        canImport={hasPermission('cxc.add_esquemacomision')}
+                        onExport={() => setIsExportModalOpen(true)}
+                        canExport={hasPermission('cxc.view_esquemacomision')}
+                    />
                 </div>
                 {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
             </div>

--- a/frontend/luximia_erp_ui/app/(catalogos)/formas-pago/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/formas-pago/page.jsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import {
   getFormasPago,
   createFormaPago,
@@ -16,7 +15,7 @@ import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const COLUMNS_DISPLAY = [
   { header: 'Enganche (%)', render: (row) => row.enganche },
@@ -182,42 +181,17 @@ export default function FormasPagoPage() {
       <div className="flex-shrink-0">
         <div className="flex justify-between items-center mb-10">
           <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Formas de Pago</h1>
-          <div className="flex items-center space-x-3">
-            {hasPermission('cxc.can_view_inactive_records') && (
-              <button
-                onClick={() => setShowInactive(!showInactive)}
-                className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
-              >
-                {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-              </button>
-            )}
-            {hasPermission('cxc.add_formapago') && (
-              <button
-                onClick={handleCreateClick}
-                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
-              >
-                + Nueva Forma
-              </button>
-            )}
-            {hasPermission('cxc.add_formapago') && (
-              <Link
-                href="/importar/formas-pago"
-                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                title="Importar desde Excel"
-              >
-                <Upload className="h-6 w-6" />
-              </Link>
-            )}
-            {hasPermission('cxc.view_formapago') && (
-              <button
-                onClick={() => setIsExportModalOpen(true)}
-                className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                title="Exportar a Excel"
-              >
-                <Download className="h-6 w-6" />
-              </button>
-            )}
-          </div>
+          <ActionButtons
+            showInactive={showInactive}
+            onToggleInactive={() => setShowInactive(!showInactive)}
+            canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+            onCreate={handleCreateClick}
+            canCreate={hasPermission('cxc.add_formapago')}
+            importHref="/importar/formas-pago"
+            canImport={hasPermission('cxc.add_formapago')}
+            onExport={() => setIsExportModalOpen(true)}
+            canExport={hasPermission('cxc.view_formapago')}
+          />
         </div>
       </div>
 

--- a/frontend/luximia_erp_ui/app/(catalogos)/monedas/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/monedas/page.jsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import {
   getMonedas,
   createMoneda,
@@ -16,7 +15,7 @@ import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const MONEDA_COLUMNAS_DISPLAY = [
   { header: 'Código', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.codigo}</span> },
@@ -171,42 +170,17 @@ export default function MonedasPage() {
       <div className="flex-shrink-0">
         <div className="flex justify-between items-center mb-10">
           <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Monedas</h1>
-          <div className="flex items-center space-x-3">
-            {hasPermission('cxc.can_view_inactive_records') && (
-              <button
-                onClick={() => setShowInactive(!showInactive)}
-                className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
-              >
-                {showInactive ? 'Ver Activas' : 'Ver Inactivas'}
-              </button>
-            )}
-            {hasPermission('cxc.add_moneda') && (
-              <button
-                onClick={handleCreateClick}
-                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
-              >
-                + Nueva Moneda
-              </button>
-            )}
-            {hasPermission('cxc.add_moneda') && (
-              <Link
-                href="/importar/monedas"
-                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                title="Importar desde Excel"
-              >
-                <Upload className="h-6 w-6" />
-              </Link>
-            )}
-            {hasPermission('cxc.view_moneda') && (
-              <button
-                onClick={() => setIsExportModalOpen(true)}
-                className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                title="Exportar a Excel"
-              >
-                <Download className="h-6 w-6" />
-              </button>
-            )}
-          </div>
+          <ActionButtons
+            showInactive={showInactive}
+            onToggleInactive={() => setShowInactive(!showInactive)}
+            canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+            onCreate={handleCreateClick}
+            canCreate={hasPermission('cxc.add_moneda')}
+            importHref="/importar/monedas"
+            canImport={hasPermission('cxc.add_moneda')}
+            onExport={() => setIsExportModalOpen(true)}
+            canExport={hasPermission('cxc.view_moneda')}
+          />
         </div>
         {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
       </div>

--- a/frontend/luximia_erp_ui/app/(catalogos)/planes-pago/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/planes-pago/page.jsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/context/AuthContext';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
 import Overlay from '@/components/loaders/Overlay';
 
@@ -217,32 +217,16 @@ export default function PlanesPagoPage() {
                 <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Planes de Pago</h1>
                 <div className="flex items-center space-x-3">
                     {hasPermission('cxc.add_planpago') && (
-                        <>
-                            <input ref={fileInputRef} type="file" accept=".csv" onChange={handleFileChange} className="hidden" />
-                            <button
-                                onClick={handleCreateClick}
-                                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg"
-                            >
-                                + Nuevo Plan
-                            </button>
-                            <button
-                                onClick={handleImportClick}
-                                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg"
-                                title="Importar desde Excel"
-                            >
-                                <Upload className="h-6 w-6" />
-                            </button>
-                        </>
+                        <input ref={fileInputRef} type="file" accept=".csv" onChange={handleFileChange} className="hidden" />
                     )}
-                    {hasPermission('cxc.view_planpago') && (
-                        <button
-                            onClick={() => setIsExportModalOpen(true)}
-                            className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg"
-                            title="Exportar a Excel"
-                        >
-                            <Download className="h-6 w-6" />
-                        </button>
-                    )}
+                    <ActionButtons
+                        onCreate={handleCreateClick}
+                        canCreate={hasPermission('cxc.add_planpago')}
+                        onImport={handleImportClick}
+                        canImport={hasPermission('cxc.add_planpago')}
+                        onExport={() => setIsExportModalOpen(true)}
+                        canExport={hasPermission('cxc.view_planpago')}
+                    />
                 </div>
             </div>
             {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}

--- a/frontend/luximia_erp_ui/app/(catalogos)/proyectos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/proyectos/page.jsx
@@ -2,14 +2,13 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import { getProyectos, createProyecto, updateProyecto, deleteProyecto, getInactiveProyectos, hardDeleteProyecto, exportProyectosExcel } from '@/services/api';
 import { useAuth } from '@/context/AuthContext';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form'; // <-- Usa el FormModal
 import ExportModal from '@/components/ui/modals/Export';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 import { useResponsivePageSize } from '@/hooks/useResponsivePageSize';
 import { formatCurrency } from '@/utils/formatters';
 
@@ -230,30 +229,17 @@ export default function ProyectosPage() {
             <div className="flex-shrink-0">
                 <div className="flex justify-between items-center mb-10">
                     <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Proyectos</h1>
-                    <div className="flex items-center space-x-3">
-                        {hasPermission('cxc.can_view_inactive_records') && (
-                            <button onClick={() => setShowInactive(!showInactive)} className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">
-                                {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-                            </button>
-                        )}
-                        {hasPermission('cxc.add_proyecto') && (
-                            <button onClick={handleCreateClick} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">
-                                + Nuevo Proyecto
-                            </button>
-                        )}
-                        {hasPermission('cxc.add_proyecto') && (
-                            <Link
-                                href="/importar/proyectos"
-                                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg"
-                                title="Importar desde Excel"
-                            >
-                                <Upload className="h-6 w-6" />
-                            </Link>
-                        )}
-                        <button onClick={() => setIsExportModalOpen(true)} className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg" title="Exportar a Excel">
-                            <Download className="h-6 w-6" />
-                        </button>
-                    </div>
+                    <ActionButtons
+                        showInactive={showInactive}
+                        onToggleInactive={() => setShowInactive(!showInactive)}
+                        canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+                        onCreate={handleCreateClick}
+                        canCreate={hasPermission('cxc.add_proyecto')}
+                        importHref="/importar/proyectos"
+                        canImport={hasPermission('cxc.add_proyecto')}
+                        onExport={() => setIsExportModalOpen(true)}
+                        canExport
+                    />
                 </div>
                 {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
             </div>

--- a/frontend/luximia_erp_ui/app/(catalogos)/puestos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/puestos/page.jsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import {
     getPuestos,
     createPuesto,
@@ -17,7 +16,7 @@ import ReusableTable from '@/components/ui/tables/ReusableTable';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const PUESTO_COLUMNAS_DISPLAY = [
     { header: 'Nombre', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.nombre}</span> },
@@ -199,36 +198,17 @@ export default function PuestosPage() {
             <div className="flex-shrink-0">
                 <div className="flex justify-between items-center mb-10">
                     <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Puestos</h1>
-                    <div className="flex items-center space-x-3">
-                        {hasPermission('cxc.can_view_inactive_records') && (
-                            <button onClick={() => setShowInactive(!showInactive)} className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">
-                                {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-                            </button>
-                        )}
-                        {hasPermission('cxc.add_puesto') && (
-                            <button onClick={handleCreateClick} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">
-                                + Nuevo Puesto
-                            </button>
-                        )}
-                        {hasPermission('cxc.add_puesto') && (
-                            <Link
-                                href="/importar/puestos"
-                                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                                title="Importar desde Excel"
-                            >
-                                <Upload className="h-6 w-6" />
-                            </Link>
-                        )}
-                        {hasPermission('cxc.view_puesto') && (
-                            <button
-                                onClick={() => setIsExportModalOpen(true)}
-                                className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                                title="Exportar a Excel"
-                            >
-                                <Download className="h-6 w-6" />
-                            </button>
-                        )}
-                    </div>
+                    <ActionButtons
+                        showInactive={showInactive}
+                        onToggleInactive={() => setShowInactive(!showInactive)}
+                        canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+                        onCreate={handleCreateClick}
+                        canCreate={hasPermission('cxc.add_puesto')}
+                        importHref="/importar/puestos"
+                        canImport={hasPermission('cxc.add_puesto')}
+                        onExport={() => setIsExportModalOpen(true)}
+                        canExport={hasPermission('cxc.view_puesto')}
+                    />
                 </div>
                 {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
             </div>

--- a/frontend/luximia_erp_ui/app/(catalogos)/upes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/upes/page.jsx
@@ -2,7 +2,6 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import { getUPEs, getAllProyectos, createUPE, updateUPE, deleteUPE, getInactiveUpes, hardDeleteUpe, exportUpesExcel } from '@/services/api';
 import { useAuth } from '@/context/AuthContext';
 import FormModal from '@/components/ui/modals/Form';
@@ -10,7 +9,7 @@ import ExportModal from '@/components/ui/modals/Export';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import { formatCurrency } from '@/utils/formatters';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 // ### 2. Define las columnas para la tabla y la exportación ###
 const UPE_COLUMNAS_DISPLAY = [
@@ -219,26 +218,17 @@ export default function UPEsPage() {
         <div className="p-8 h-full flex flex-col">
             <div className="flex justify-between items-center mb-10">
                 <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de UPEs</h1>
-                <div className="flex items-center space-x-3">
-                    {hasPermission('cxc.can_view_inactive_records') && (
-                        <button onClick={() => setShowInactive(!showInactive)} className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">
-                            {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-                        </button>
-                    )}
-                    {hasPermission('cxc.add_upe') && (
-                        <>
-                            <button onClick={handleCreateClick} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">+ Nueva UPE</button>
-                            <Link
-                                href="/importar/upes"
-                                className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                                title="Importar desde Excel"
-                            >
-                                <Upload className="h-6 w-6" />
-                            </Link>
-                        </>
-                    )}
-                    <button onClick={() => setIsExportModalOpen(true)} className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg" title="Exportar a Excel"><Download className="h-6 w-6" /></button>
-                </div>
+                <ActionButtons
+                    showInactive={showInactive}
+                    onToggleInactive={() => setShowInactive(!showInactive)}
+                    canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+                    onCreate={handleCreateClick}
+                    canCreate={hasPermission('cxc.add_upe')}
+                    importHref="/importar/upes"
+                    canImport={hasPermission('cxc.add_upe')}
+                    onExport={() => setIsExportModalOpen(true)}
+                    canExport
+                />
             </div>
 
             {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}

--- a/frontend/luximia_erp_ui/app/(catalogos)/vendedores/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/vendedores/page.jsx
@@ -1,14 +1,13 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import Link from 'next/link';
 import { getVendedores, createVendedor, updateVendedor, deleteVendedor, getInactiveVendedores, hardDeleteVendedor, exportVendedoresExcel } from '@/services/api';
 import { useAuth } from '@/context/AuthContext';
 import FormModal from '@/components/ui/modals/Form';
 import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import ExportModal from '@/components/ui/modals/Export';
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const VENDEDOR_COLUMNAS_DISPLAY = [
     { header: 'Tipo', render: (row) => row.tipo },
@@ -176,42 +175,17 @@ export default function VendedoresPage() {
         <div className="p-8 h-full flex flex-col">
             <div className="flex justify-between items-center mb-10">
                 <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Vendedores</h1>
-                <div className="flex items-center space-x-3">
-                    {hasPermission('cxc.can_view_inactive_records') && (
-                        <button
-                            onClick={() => setShowInactive(!showInactive)}
-                            className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded-md"
-                        >
-                            {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-                        </button>
-                    )}
-                    {hasPermission('cxc.add_vendedor') && (
-                        <button
-                            onClick={handleCreateClick}
-                            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-                        >
-                            Nuevo Vendedor
-                        </button>
-                    )}
-                    {hasPermission('cxc.add_vendedor') && (
-                        <Link
-                            href="/importar/vendedores"
-                            className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                            title="Importar desde Excel"
-                        >
-                            <Upload className="h-6 w-6" />
-                        </Link>
-                    )}
-                    {hasPermission('cxc.view_vendedor') && (
-                        <button
-                            onClick={() => setIsExportModalOpen(true)}
-                            className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg transition-colors duration-200"
-                            title="Exportar a Excel"
-                        >
-                            <Download className="h-6 w-6" />
-                        </button>
-                    )}
-                </div>
+                <ActionButtons
+                    showInactive={showInactive}
+                    onToggleInactive={() => setShowInactive(!showInactive)}
+                    canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+                    onCreate={handleCreateClick}
+                    canCreate={hasPermission('cxc.add_vendedor')}
+                    importHref="/importar/vendedores"
+                    canImport={hasPermission('cxc.add_vendedor')}
+                    onExport={() => setIsExportModalOpen(true)}
+                    canExport={hasPermission('cxc.view_vendedor')}
+                />
             </div>
             {error && <p className="text-red-500 mb-4">{error}</p>}
             <div className="flex-1">

--- a/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/roles/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/roles/page.jsx
@@ -20,7 +20,7 @@ import ExportModal from '@/components/ui/modals/Export';
 import ImportModal from '@/components/ui/modals/Import';
 import { translatePermission, translateModel, shouldDisplayPermission } from '@/utils/permissions';
 import Overlay from '@/components/loaders/Overlay';
-import { Upload, Download } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 // --- Constantes de Configuración ---
 const ROLES_COLUMNAS_DISPLAY = [
@@ -230,26 +230,17 @@ export default function RolesPage() {
         <div className="p-8 h-full flex flex-col">
         <div className="flex justify-between items-center mb-10">
             <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Roles</h1>
-            <div className="flex items-center space-x-3">
-                {hasPermission('cxc.can_view_inactive_records') && (
-                    <button onClick={() => setShowInactive(!showInactive)} className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">
-                        {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-                    </button>
-                )}
-                {hasPermission('cxc.add_group') && (
-                    <>
-                        <button onClick={openModalForCreate} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">
-                            + Nuevo Rol
-                        </button>
-                        <button onClick={() => setIsImportModalOpen(true)} className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg" title="Importar desde Excel">
-                            <Upload className="h-6 w-6" />
-                        </button>
-                    </>
-                )}
-                <button onClick={() => setIsExportModalOpen(true)} className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg" title="Exportar a Excel">
-                    <Download className="h-6 w-6" />
-                </button>
-            </div>
+            <ActionButtons
+                showInactive={showInactive}
+                onToggleInactive={() => setShowInactive(!showInactive)}
+                canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+                onCreate={openModalForCreate}
+                canCreate={hasPermission('cxc.add_group')}
+                onImport={() => setIsImportModalOpen(true)}
+                canImport={hasPermission('cxc.add_group')}
+                onExport={() => setIsExportModalOpen(true)}
+                canExport
+            />
         </div>
 
             {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}

--- a/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/usuarios/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/configuraciones/usuarios/page.jsx
@@ -21,7 +21,8 @@ import ConfirmationModal from '@/components/ui/modals/Confirmation';
 import ExportModal from '@/components/ui/modals/Export';
 import ImportModal from '@/components/ui/modals/Import';
 import Overlay from '@/components/loaders/Overlay';
-import { Key, ShieldCheck, Mail, Upload, Download } from 'lucide-react';
+import { Key, ShieldCheck, Mail } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const USUARIO_COLUMNAS_DISPLAY = [
     { header: 'Usuario', render: (row) => <span className="font-medium text-gray-900 dark:text-white">{row.username}</span> },
@@ -242,26 +243,17 @@ export default function UsuariosPage() {
         <div className="p-8">
             <div className="flex flex-wrap justify-between items-center mb-10 gap-4">
                 <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Gestión de Usuarios</h1>
-                <div className="flex gap-2">
-                    {hasPermission('cxc.can_view_inactive_records') && (
-                        <button onClick={() => setShowInactive(!showInactive)} className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">
-                            {showInactive ? 'Ver Activos' : 'Ver Inactivos'}
-                        </button>
-                    )}
-                    {hasPermission('cxc.add_user') && (
-                        <>
-                            <button onClick={openModalForCreate} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">
-                                + Nuevo Usuario
-                            </button>
-                            <button onClick={() => setIsImportModalOpen(true)} className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg" title="Importar desde Excel">
-                                <Upload className="h-6 w-6" />
-                            </button>
-                        </>
-                    )}
-                    <button onClick={() => setIsExportModalOpen(true)} className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg" title="Exportar a Excel">
-                        <Download className="h-6 w-6" />
-                    </button>
-                </div>
+                <ActionButtons
+                    showInactive={showInactive}
+                    onToggleInactive={() => setShowInactive(!showInactive)}
+                    canToggleInactive={hasPermission('cxc.can_view_inactive_records')}
+                    onCreate={openModalForCreate}
+                    canCreate={hasPermission('cxc.add_user')}
+                    onImport={() => setIsImportModalOpen(true)}
+                    canImport={hasPermission('cxc.add_user')}
+                    onExport={() => setIsExportModalOpen(true)}
+                    canExport
+                />
             </div>
 
             {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}

--- a/frontend/luximia_erp_ui/app/(operaciones)/contratos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/contratos/page.jsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { getContratos, exportContratosExcel } from '@/services/api';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import Loader from '@/components/loaders/Overlay'; // Usamos el Overlay para la carga
-import { Download, Upload } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 export default function ContratosPage() {
     const [contratos, setContratos] = useState([]);
@@ -75,22 +75,12 @@ export default function ContratosPage() {
         <div className="p-8">
             <div className="flex justify-between items-center mb-4">
                 <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-200">Contratos</h1>
-                <div className="flex items-center space-x-3">
-                    <Link
-                        href="/importar/contratos"
-                        className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg"
-                        title="Importar desde Excel"
-                    >
-                        <Upload className="h-5 w-5" />
-                    </Link>
-                    <button
-                        onClick={handleExport}
-                        className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg"
-                        title="Exportar a Excel"
-                    >
-                        <Download className="h-5 w-5" />
-                    </button>
-                </div>
+                <ActionButtons
+                    importHref="/importar/contratos"
+                    canImport
+                    onExport={handleExport}
+                    canExport
+                />
             </div>
             <ReusableTable
                 data={contratos}

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/clientes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/clientes/page.jsx
@@ -3,7 +3,6 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { importarClientes } from '@/services/api';
-import Link from 'next/link';
 
 export default function ImportarClientesPage() {
     const [selectedFile, setSelectedFile] = useState(null);

--- a/frontend/luximia_erp_ui/app/(operaciones)/importar/pagos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/importar/pagos/page.jsx
@@ -4,7 +4,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 // ### CAMBIO: Importamos la función correcta ###
 import { importarPagosHistoricos } from '@/services/api';
-import Link from 'next/link';
 
 // ### CAMBIO: Renombramos el componente ###
 export default function ImportarPagosPage() {

--- a/frontend/luximia_erp_ui/app/(operaciones)/pagos/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/pagos/page.jsx
@@ -9,7 +9,7 @@ import Link from 'next/link';
 import Overlay from '@/components/loaders/Overlay';
 import Modal from '@/components/ui/modals';
 import { formatCurrency } from '@/utils/formatters';
-import { Upload, Download } from 'lucide-react';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const PAGO_COLUMNAS_EXPORT = [
     { id: 'fecha_pago', label: 'Fecha de Pago' },
@@ -166,34 +166,14 @@ export default function PagosPage() {
         <div className="p-8 h-full flex flex-col">
             <div className="flex justify-between items-center mb-10">
                 <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Pagos Registrados</h1>
-                <div className="flex items-center space-x-3">
-                    {hasPermission('cxc.add_pago') && (
-                        <button
-                            onClick={handleCreateClick}
-                            className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg"
-                        >
-                            + Registrar Pago
-                        </button>
-                    )}
-                    {hasPermission('cxc.add_pago') && (
-                        <Link
-                            href="/importar/pagos"
-                            className="bg-purple-600 hover:bg-purple-700 text-white font-bold p-2 rounded-lg"
-                            title="Importar desde Excel"
-                        >
-                            <Upload className="h-6 w-6" />
-                        </Link>
-                    )}
-                    {hasPermission('cxc.view_pago') && (
-                        <button
-                            onClick={handleExport}
-                            className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg"
-                            title="Exportar a Excel"
-                        >
-                            <Download className="h-6 w-6" />
-                        </button>
-                    )}
-                </div>
+                <ActionButtons
+                    onCreate={handleCreateClick}
+                    canCreate={hasPermission('cxc.add_pago')}
+                    importHref="/importar/pagos"
+                    canImport={hasPermission('cxc.add_pago')}
+                    onExport={handleExport}
+                    canExport={hasPermission('cxc.view_pago')}
+                />
             </div>
             {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
             <div ref={ref} className="flex-grow min-h-0 relative">

--- a/frontend/luximia_erp_ui/components/ui/ActionButtons.jsx
+++ b/frontend/luximia_erp_ui/components/ui/ActionButtons.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import Link from 'next/link';
+import { Eye, EyeOff, Plus, Upload, Download } from 'lucide-react';
+
+export default function ActionButtons({
+  showInactive = false,
+  onToggleInactive,
+  canToggleInactive = false,
+  onCreate,
+  canCreate = false,
+  onImport,
+  importHref,
+  canImport = false,
+  onExport,
+  canExport = false,
+}) {
+  return (
+    <div className="flex items-center space-x-3">
+      {canToggleInactive && (
+        <button
+          onClick={onToggleInactive}
+          className="bg-gray-500 hover:bg-gray-600 text-white p-2 rounded-lg transition-colors duration-200"
+          title={showInactive ? 'Ver Activos' : 'Ver Inactivos'}
+        >
+          {showInactive ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+        </button>
+      )}
+      {canCreate && (
+        <button
+          onClick={onCreate}
+          className="bg-blue-600 hover:bg-blue-700 text-white p-2 rounded-lg transition-transform duration-200 hover:scale-110"
+          title="Agregar"
+        >
+          <Plus className="h-5 w-5" />
+        </button>
+      )}
+      {canImport && (
+        importHref ? (
+          <Link
+            href={importHref}
+            className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-lg transition-transform duration-200 hover:scale-110"
+            title="Importar"
+          >
+            <Upload className="h-5 w-5" />
+          </Link>
+        ) : (
+          <button
+            onClick={onImport}
+            className="bg-purple-600 hover:bg-purple-700 text-white p-2 rounded-lg transition-transform duration-200 hover:scale-110"
+            title="Importar"
+          >
+            <Upload className="h-5 w-5" />
+          </button>
+        )
+      )}
+      {canExport && (
+        <button
+          onClick={onExport}
+          className="bg-green-600 hover:bg-green-700 text-white p-2 rounded-lg transition-transform duration-200 hover:scale-110"
+          title="Exportar"
+        >
+          <Download className="h-5 w-5" />
+        </button>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- centralize create/import/export/toggle controls in new `ActionButtons` component with lucide icons and hover animations
- replace duplicated button blocks across catalog, configuration, and operations pages
- clean up unused imports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acda4c8e6c8332a261f6e9ed3b4e33