### PR TITLE
feat: improve report selection and filters

### DIFF
--- a/frontend/luximia_erp_ui/app/(operaciones)/reportes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/reportes/page.jsx
@@ -12,8 +12,7 @@ import {
     getContratos,
 } from '@/services/api';
 import { useAuth } from '@/context/AuthContext';
-import ExportModal from '@/components/ui/modals/Export';
-import { Download } from 'lucide-react';
+import { Download, Eye } from 'lucide-react';
 
 const PROYECTO_COLUMNAS_EXPORT = [
     { id: 'id', label: 'ID' },
@@ -78,37 +77,72 @@ const REPORTES = {
         fn: exportContratosExcel,
         fetch: getContratos,
         filename: 'reporte_contratos.xlsx',
+        dateField: 'fecha_venta',
     },
 };
 
+function getNestedValue(obj, path) {
+    return path.split('__').reduce((acc, part) => (acc ? acc[part] : undefined), obj);
+}
+
 export default function ReportesPage() {
     const { hasPermission } = useAuth();
-    const [current, setCurrent] = useState(null);
+    const [selectedReport, setSelectedReport] = useState('');
     const [selectedColumns, setSelectedColumns] = useState({});
     const [reportSearch, setReportSearch] = useState('');
     const [previewData, setPreviewData] = useState([]);
+    const [previewVisible, setPreviewVisible] = useState(false);
     const [previewSearch, setPreviewSearch] = useState('');
     const [loadingPreview, setLoadingPreview] = useState(false);
     const [onlyActive, setOnlyActive] = useState(false);
     const [showActiveFilter, setShowActiveFilter] = useState(false);
+    const [filterField, setFilterField] = useState('');
+    const [filterValue, setFilterValue] = useState('');
+    const [dateFilter, setDateFilter] = useState('');
 
     if (!hasPermission('cxc.can_export')) {
         return <div className="p-8">Sin permiso para exportar reportes.</div>;
     }
 
-    const openModal = async (key) => {
-        const cols = REPORTES[key].columns;
-        const initial = {};
-        cols.forEach((c) => (initial[c.id] = true));
-        setSelectedColumns(initial);
-        setPreviewData([]);
-        setPreviewSearch('');
-        setOnlyActive(false);
-        setShowActiveFilter(false);
-        setCurrent(key);
+    const filteredReports = Object.entries(REPORTES).filter(([_, rep]) =>
+        rep.label.toLowerCase().includes(reportSearch.toLowerCase()),
+    );
+
+    const handleSelectReport = (e) => {
+        const key = e.target.value;
+        setSelectedReport(key);
+        if (key) {
+            const cols = REPORTES[key].columns;
+            const initial = {};
+            cols.forEach((c) => (initial[c.id] = true));
+            setSelectedColumns(initial);
+            setPreviewData([]);
+            setPreviewVisible(false);
+            setPreviewSearch('');
+            setOnlyActive(false);
+            setShowActiveFilter(false);
+            setFilterField('');
+            setFilterValue('');
+            setDateFilter('');
+        }
+    };
+
+    const handleColumnChange = (e) => {
+        const { name, checked } = e.target;
+        setSelectedColumns((prev) => ({ ...prev, [name]: checked }));
+    };
+
+    const handlePreview = async () => {
+        if (!selectedReport) return;
         setLoadingPreview(true);
+        setPreviewVisible(true);
         try {
-            const res = await REPORTES[key].fetch(1, 50);
+            const cfg = REPORTES[selectedReport];
+            const filters = {};
+            if (dateFilter && cfg.dateField) {
+                filters[cfg.dateField] = dateFilter;
+            }
+            const res = await cfg.fetch(1, 50, filters);
             const data = res.data.results || res.data;
             setPreviewData(data);
             setShowActiveFilter(data.some((row) => typeof row.activo !== 'undefined'));
@@ -119,17 +153,21 @@ export default function ReportesPage() {
         }
     };
 
-    const handleColumnChange = (e) => {
-        const { name, checked } = e.target;
-        setSelectedColumns(prev => ({ ...prev, [name]: checked }));
-    };
-
     const handleDownload = async () => {
-        const cfg = REPORTES[current];
-        const columnsToExport = cfg.columns.filter(c => selectedColumns[c.id]).map(c => c.id);
+        if (!selectedReport) return;
+        const cfg = REPORTES[selectedReport];
+        const columnsToExport = cfg.columns
+            .filter((c) => selectedColumns[c.id])
+            .map((c) => c.id);
+        const filters = {};
+        if (dateFilter && cfg.dateField) {
+            filters[cfg.dateField] = dateFilter;
+        }
         try {
-            const res = await cfg.fn(columnsToExport);
-            const blob = new Blob([res.data], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+            const res = await cfg.fn(columnsToExport, filters);
+            const blob = new Blob([res.data], {
+                type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            });
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
@@ -141,13 +179,20 @@ export default function ReportesPage() {
         } catch (err) {
             // eslint-disable-next-line no-alert
             alert('Error al generar el reporte');
-        } finally {
-            setCurrent(null);
         }
     };
 
+    const visibleColumns = REPORTES[selectedReport]?.columns.filter((c) => selectedColumns[c.id]) || [];
+
     const filteredPreview = previewData
         .filter((row) => (!onlyActive || row.activo))
+        .filter((row) => {
+            if (filterField && filterValue) {
+                const val = getNestedValue(row, filterField);
+                return val ? val.toString().toLowerCase().includes(filterValue.toLowerCase()) : false;
+            }
+            return true;
+        })
         .filter((row) => {
             if (!previewSearch) return true;
             return Object.values(row).some((val) =>
@@ -155,10 +200,6 @@ export default function ReportesPage() {
             );
         })
         .slice(0, 10);
-
-    const filteredReports = Object.entries(REPORTES).filter(([_, rep]) =>
-        rep.label.toLowerCase().includes(reportSearch.toLowerCase()),
-    );
 
     return (
         <div className="p-8 h-full flex flex-col space-y-4">
@@ -168,42 +209,143 @@ export default function ReportesPage() {
                 placeholder="Buscar reporte..."
                 value={reportSearch}
                 onChange={(e) => setReportSearch(e.target.value)}
-                className="mb-2 px-3 py-2 border rounded-md max-w-sm dark:bg-gray-800 dark:border-gray-700"
+                className="px-3 py-2 border rounded-md max-w-sm dark:bg-gray-800 dark:border-gray-700"
             />
-            <div className="space-y-4">
+            <select
+                value={selectedReport}
+                onChange={handleSelectReport}
+                className="px-3 py-2 border rounded-md max-w-sm dark:bg-gray-800 dark:border-gray-700"
+            >
+                <option value="">Seleccione reporte...</option>
                 {filteredReports.map(([key, rep]) => (
-                    <div
-                        key={key}
-                        className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow flex justify-between items-center"
-                    >
-                        <span className="font-medium">{rep.label}</span>
+                    <option key={key} value={key}>
+                        {rep.label}
+                    </option>
+                ))}
+            </select>
+
+            {selectedReport && (
+                <>
+                    {REPORTES[selectedReport].dateField && (
+                        <input
+                            type="date"
+                            value={dateFilter}
+                            onChange={(e) => setDateFilter(e.target.value)}
+                            className="px-3 py-2 border rounded-md max-w-sm dark:bg-gray-800 dark:border-gray-700"
+                        />
+                    )}
+
+                    <div className="flex items-center space-x-2 mt-2">
                         <button
-                            onClick={() => openModal(key)}
-                            className="bg-green-600 hover:bg-green-700 text-white font-bold p-2 rounded-lg"
+                            onClick={handlePreview}
+                            className="bg-blue-600 hover:bg-blue-700 text-white p-2 rounded-lg"
+                            title="Vista previa"
+                        >
+                            <Eye className="h-6 w-6" />
+                        </button>
+                        <button
+                            onClick={handleDownload}
+                            className="bg-green-600 hover:bg-green-700 text-white p-2 rounded-lg"
                             title="Descargar"
                         >
                             <Download className="h-6 w-6" />
                         </button>
                     </div>
-                ))}
-            </div>
-            {current && (
-                <ExportModal
-                    isOpen={true}
-                    onClose={() => setCurrent(null)}
-                    columns={REPORTES[current].columns}
-                    selectedColumns={selectedColumns}
-                    onColumnChange={handleColumnChange}
-                    onDownload={handleDownload}
-                    data={filteredPreview}
-                    searchValue={previewSearch}
-                    onSearchChange={setPreviewSearch}
-                    loading={loadingPreview}
-                    withPreview
-                    showActiveFilter={showActiveFilter}
-                    onlyActive={onlyActive}
-                    onToggleActive={() => setOnlyActive((prev) => !prev)}
-                />
+
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-4">
+                        {REPORTES[selectedReport].columns.map((col) => (
+                            <label key={col.id} className="flex items-center space-x-2">
+                                <input
+                                    type="checkbox"
+                                    name={col.id}
+                                    checked={!!selectedColumns[col.id]}
+                                    onChange={handleColumnChange}
+                                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                                />
+                                <span className="text-gray-700 dark:text-gray-300">{col.label}</span>
+                            </label>
+                        ))}
+                    </div>
+
+                    {previewVisible && (
+                        <div className="space-y-2 mt-4">
+                            <div className="flex items-center gap-2">
+                                <input
+                                    type="text"
+                                    placeholder="Buscar..."
+                                    value={previewSearch}
+                                    onChange={(e) => setPreviewSearch(e.target.value)}
+                                    className="flex-1 px-2 py-1 border rounded-md dark:bg-gray-700 dark:border-gray-600"
+                                />
+                                <select
+                                    value={filterField}
+                                    onChange={(e) => setFilterField(e.target.value)}
+                                    className="px-2 py-1 border rounded-md dark:bg-gray-700 dark:border-gray-600"
+                                >
+                                    <option value="">Campo...</option>
+                                    {REPORTES[selectedReport].columns.map((col) => (
+                                        <option key={col.id} value={col.id}>
+                                            {col.label}
+                                        </option>
+                                    ))}
+                                </select>
+                                <input
+                                    type="text"
+                                    placeholder="Valor"
+                                    value={filterValue}
+                                    onChange={(e) => setFilterValue(e.target.value)}
+                                    className="px-2 py-1 border rounded-md dark:bg-gray-700 dark:border-gray-600"
+                                />
+                                {showActiveFilter && (
+                                    <label className="flex items-center space-x-2 text-sm text-gray-700 dark:text-gray-300">
+                                        <input
+                                            type="checkbox"
+                                            checked={onlyActive}
+                                            onChange={() => setOnlyActive((prev) => !prev)}
+                                            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                                        />
+                                        <span>Solo activos</span>
+                                    </label>
+                                )}
+                            </div>
+
+                            <div className="overflow-auto border rounded max-h-64 dark:border-gray-700">
+                                {loadingPreview ? (
+                                    <div className="p-4 text-center text-gray-500 dark:text-gray-400">Cargando...</div>
+                                ) : (
+                                    <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-xs">
+                                        <thead className="bg-gray-50 dark:bg-gray-700">
+                                            <tr>
+                                                {visibleColumns.map((col) => (
+                                                    <th
+                                                        key={col.id}
+                                                        className="px-2 py-1 text-left font-medium text-gray-700 dark:text-gray-300"
+                                                    >
+                                                        {col.label}
+                                                    </th>
+                                                ))}
+                                            </tr>
+                                        </thead>
+                                        <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                                            {filteredPreview.map((row, idx) => (
+                                                <tr key={idx} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+                                                    {visibleColumns.map((col) => (
+                                                        <td
+                                                            key={col.id}
+                                                            className="px-2 py-1 text-gray-700 dark:text-gray-300"
+                                                        >
+                                                            {getNestedValue(row, col.id) ?? ''}
+                                                        </td>
+                                                    ))}
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </>
             )}
         </div>
     );

--- a/frontend/luximia_erp_ui/services/api.js
+++ b/frontend/luximia_erp_ui/services/api.js
@@ -117,17 +117,22 @@ export const importarRoles = (formData) =>
 
 
 // ===================== CXC (paginados) =====================
-export const getProyectos = (page = 1, pageSize = 15) => apiClient.get(`/cxc/proyectos/?page=${page}&page_size=${pageSize}`);
-export const getClientes = (page = 1, pageSize = 15) => apiClient.get(`/cxc/clientes/?page=${page}&page_size=${pageSize}`);
-export const getUPEs = (page = 1, pageSize = 15) => apiClient.get(`/cxc/upes/?page=${page}&page_size=${pageSize}`);
+export const getProyectos = (page = 1, pageSize = 15, filters = {}) =>
+  apiClient.get('/cxc/proyectos/', { params: { page, page_size: pageSize, ...filters } });
+export const getClientes = (page = 1, pageSize = 15, filters = {}) =>
+  apiClient.get('/cxc/clientes/', { params: { page, page_size: pageSize, ...filters } });
+export const getUPEs = (page = 1, pageSize = 15, filters = {}) =>
+  apiClient.get('/cxc/upes/', { params: { page, page_size: pageSize, ...filters } });
 export const getBancos = (page = 1, pageSize = 15) => apiClient.get(`/cxc/bancos/?page=${page}&page_size=${pageSize}`);
 export const getMonedas = (page = 1, pageSize = 15) => apiClient.get(`/cxc/monedas/?page=${page}&page_size=${pageSize}`);
 export const getDepartamentos = (page = 1, pageSize = 15) => apiClient.get(`/cxc/departamentos/?page=${page}&page_size=${pageSize}`);
 export const getPuestos = (page = 1, pageSize = 15) => apiClient.get(`/cxc/puestos/?page=${page}&page_size=${pageSize}`);
 export const getEmpleados = (page = 1, pageSize = 15) => apiClient.get(`/cxc/empleados/?page=${page}&page_size=${pageSize}`);
 export const getVendedores = (page = 1, pageSize = 15) => apiClient.get(`/cxc/vendedores/?page=${page}&page_size=${pageSize}`);
-export const getPresupuestos = (page = 1, pageSize = 15) => apiClient.get(`/cxc/presupuestos/?page=${page}&page_size=${pageSize}`);
-export const getContratos = (page = 1, pageSize = 15) => apiClient.get(`/cxc/contratos/?page=${page}&page_size=${pageSize}`);
+export const getPresupuestos = (page = 1, pageSize = 15) =>
+  apiClient.get(`/cxc/presupuestos/?page=${page}&page_size=${pageSize}`);
+export const getContratos = (page = 1, pageSize = 15, filters = {}) =>
+  apiClient.get('/cxc/contratos/', { params: { page, page_size: pageSize, ...filters } });
 export const getPagos = (page = 1, pageSize = 15) => apiClient.get(`/cxc/pagos/?page=${page}&page_size=${pageSize}`);
 
 // ===================== Bancos =====================
@@ -154,7 +159,8 @@ export const updateCliente = (id, data) => apiClient.patch(`/cxc/clientes/${id}/
 export const deleteCliente = (id) => apiClient.delete(`/cxc/clientes/${id}/`);
 export const getInactiveClientes = () => apiClient.get('/cxc/clientes/inactivos/');
 export const hardDeleteCliente = (id) => apiClient.delete(`/cxc/clientes/${id}/hard/`);
-export const exportClientesExcel = (columns) => apiClient.post('/cxc/clientes/exportar-excel/', { columns }, { responseType: 'blob' });
+export const exportClientesExcel = (columns, filters = {}) =>
+  apiClient.post('/cxc/clientes/exportar-excel/', { columns }, { params: filters, responseType: 'blob' });
 export const importarClientes = (formData) => apiClient.post('/cxc/clientes/importar-excel/', formData, { headers: { 'Content-Type': 'multipart/form-data' } });
 
 // ===================== Departamentos =====================
@@ -200,7 +206,8 @@ export const updateProyecto = (id, data) => apiClient.patch(`/cxc/proyectos/${id
 export const deleteProyecto = (id) => apiClient.delete(`/cxc/proyectos/${id}/`);
 export const getInactiveProyectos = () => apiClient.get('/cxc/proyectos/inactivos/');
 export const hardDeleteProyecto = (id) => apiClient.delete(`/cxc/proyectos/${id}/hard/`);
-export const exportProyectosExcel = (columns) => apiClient.post('/cxc/proyectos/exportar-excel/', { columns }, { responseType: 'blob' });
+export const exportProyectosExcel = (columns, filters = {}) =>
+  apiClient.post('/cxc/proyectos/exportar-excel/', { columns }, { params: filters, responseType: 'blob' });
 export const importarProyectos = (formData) => apiClient.post('/cxc/proyectos/importar-excel/', formData, { headers: { 'Content-Type': 'multipart/form-data' } });
 export const getAllProyectos = () => apiClient.get('/cxc/proyectos/?page_size=1000');
 
@@ -210,7 +217,8 @@ export const updateUPE = (id, data) => apiClient.patch(`/cxc/upes/${id}/`, data)
 export const deleteUPE = (id) => apiClient.delete(`/cxc/upes/${id}/`);
 export const getInactiveUpes = () => apiClient.get('/cxc/upes/inactivos/');
 export const hardDeleteUpe = (id) => apiClient.delete(`/cxc/upes/${id}/hard/`);
-export const exportUpesExcel = (columns) => apiClient.post('/cxc/upes/exportar-excel/', { columns }, { responseType: 'blob' });
+export const exportUpesExcel = (columns, filters = {}) =>
+  apiClient.post('/cxc/upes/exportar-excel/', { columns }, { params: filters, responseType: 'blob' });
 export const importarUPEs = (formData) => apiClient.post('/cxc/upes/importar-excel/', formData, { headers: { 'Content-Type': 'multipart/form-data' } });
 
 // ===================== Clientes-Proyectos-Presupuestos =====================
@@ -253,8 +261,11 @@ export const descargarEstadoDeCuentaPDF = (contratoId, columns) =>
   apiClient.post(`/cxc/contratos/${contratoId}/descargar-pdf/`, { columns }, { responseType: 'blob' });
 export const descargarEstadoDeCuentaExcel = (contratoId, planCols, pagoCols) =>
   apiClient.post(`/cxc/contratos/${contratoId}/descargar-excel/`, { plan_cols: planCols, pago_cols: pagoCols }, { responseType: 'blob' });
-export const exportContratosExcel = (columns) =>
-  apiClient.post('/cxc/contratos/exportar-excel/', { columns }, { responseType: 'blob' });
+export const exportContratosExcel = (columns, filters = {}) =>
+  apiClient.post('/cxc/contratos/exportar-excel/', { columns }, {
+    params: filters,
+    responseType: 'blob',
+  });
 export const importarContratos = (formData) =>
   apiClient.post('/cxc/contratos/importar-excel/', formData, {
     headers: { 'Content-Type': 'multipart/form-data' },


### PR DESCRIPTION
## Summary
- replace report list with searchable selector and column checkboxes
- add preview and download actions with optional date and field filters
- allow report API helpers to accept query filters

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace322e5b88332b233c535c0c294ca