### PR TITLE
feat: add missing reports to export page

### DIFF
--- a/frontend/luximia_erp_ui/app/(operaciones)/reportes/page.jsx
+++ b/frontend/luximia_erp_ui/app/(operaciones)/reportes/page.jsx
@@ -6,10 +6,14 @@ import {
     exportClientesExcel,
     exportUpesExcel,
     exportContratosExcel,
+    exportPlanesPagoExcel,
+    exportPagosExcel,
     getProyectos,
     getClientes,
     getUPEs,
     getContratos,
+    getPlanesPago,
+    getPagos,
 } from '@/services/api';
 import { useAuth } from '@/context/AuthContext';
 import { Download, Eye } from 'lucide-react';
@@ -49,6 +53,32 @@ const CONTRATO_COLUMNAS_EXPORT = [
     { id: 'estado', label: 'Estado' },
 ];
 
+const PLANPAGO_COLUMNAS_EXPORT = [
+    { id: 'id', label: 'ID' },
+    { id: 'cliente', label: 'Cliente' },
+    { id: 'upe', label: 'UPE' },
+    { id: 'fecha_programada', label: 'Fecha Programada' },
+    { id: 'monto_programado', label: 'Monto Programado' },
+    { id: 'moneda', label: 'Moneda' },
+    { id: 'forma_pago', label: 'Forma de Pago' },
+];
+
+const PAGO_COLUMNAS_EXPORT = [
+    { id: 'fecha_pago', label: 'Fecha de Pago' },
+    { id: 'concepto', label: 'Concepto' },
+    { id: 'metodo_pago', label: 'Método' },
+    { id: 'ordenante', label: 'Ordenante' },
+    { id: 'monto_pagado', label: 'Monto Pagado' },
+    { id: 'moneda_pagada', label: 'Moneda' },
+    { id: 'tipo_cambio', label: 'Tipo de Cambio' },
+    { id: 'valor_mxn', label: 'Valor (MXN)' },
+    { id: 'banco_origen', label: 'Banco Origen' },
+    { id: 'num_cuenta_origen', label: 'Cuenta Origen' },
+    { id: 'banco_destino', label: 'Banco Destino' },
+    { id: 'cuenta_beneficiaria', label: 'Cuenta Beneficiaria' },
+    { id: 'comentarios', label: 'Comentarios' },
+];
+
 const REPORTES = {
     proyectos: {
         label: 'Proyectos',
@@ -78,6 +108,22 @@ const REPORTES = {
         fetch: getContratos,
         filename: 'reporte_contratos.xlsx',
         dateField: 'fecha_venta',
+    },
+    planes_pago: {
+        label: 'Planes de Pago',
+        columns: PLANPAGO_COLUMNAS_EXPORT,
+        fn: exportPlanesPagoExcel,
+        fetch: getPlanesPago,
+        filename: 'reporte_planes_pago.xlsx',
+        dateField: 'fecha_programada',
+    },
+    pagos: {
+        label: 'Pagos',
+        columns: PAGO_COLUMNAS_EXPORT,
+        fn: exportPagosExcel,
+        fetch: getPagos,
+        filename: 'reporte_pagos.xlsx',
+        dateField: 'fecha_pago',
     },
 };
 

--- a/frontend/luximia_erp_ui/services/api.js
+++ b/frontend/luximia_erp_ui/services/api.js
@@ -133,7 +133,8 @@ export const getPresupuestos = (page = 1, pageSize = 15) =>
   apiClient.get(`/cxc/presupuestos/?page=${page}&page_size=${pageSize}`);
 export const getContratos = (page = 1, pageSize = 15, filters = {}) =>
   apiClient.get('/cxc/contratos/', { params: { page, page_size: pageSize, ...filters } });
-export const getPagos = (page = 1, pageSize = 15) => apiClient.get(`/cxc/pagos/?page=${page}&page_size=${pageSize}`);
+export const getPagos = (page = 1, pageSize = 15, filters = {}) =>
+  apiClient.get('/cxc/pagos/', { params: { page, page_size: pageSize, ...filters } });
 
 // ===================== Bancos =====================
 export const createBanco = (data) => apiClient.post('/cxc/bancos/', data);
@@ -229,10 +230,13 @@ export const exportPresupuestosExcel = (columns) => apiClient.post('/cxc/presupu
 export const importarPresupuestos = (formData) => apiClient.post('/cxc/presupuestos/importar-excel/', formData, { headers: { 'Content-Type': 'multipart/form-data' } });
 
 // ===================== Planes de Pago =====================
-export const getPlanesPago = (page = 1, pageSize = 15) => apiClient.get(`/cxc/planes-pago/?page=${page}&page_size=${pageSize}`)
+export const getPlanesPago = (page = 1, pageSize = 15, filters = {}) =>
+  apiClient.get('/cxc/planes-pago/', { params: { page, page_size: pageSize, ...filters } });
 export const createPlanPago = (data) => apiClient.post('/cxc/planes-pago/', data);
-export const exportPlanesPagoExcel = (columns) => apiClient.post('/cxc/planes-pago/exportar-excel/', { columns }, { responseType: 'blob' });
-export const importarPlanesPago = (formData) => apiClient.post('/cxc/planes-pago/importar-excel/', formData, { headers: { 'Content-Type': 'multipart/form-data' } });
+export const exportPlanesPagoExcel = (columns, filters = {}) =>
+  apiClient.post('/cxc/planes-pago/exportar-excel/', { columns }, { params: filters, responseType: 'blob' });
+export const importarPlanesPago = (formData) =>
+  apiClient.post('/cxc/planes-pago/importar-excel/', formData, { headers: { 'Content-Type': 'multipart/form-data' } });
 
 // ===================== Esquemas de Comisión =====================
 export const getEsquemasComision = (page = 1, pageSize = 15) => apiClient.get(`/cxc/esquemas-comision/?page=${page}&page_size=${pageSize}`);
@@ -275,8 +279,8 @@ export const importarContratos = (formData) =>
 export const createPago = (data) => apiClient.post('/cxc/pagos/', data);
 export const updatePago = (id, data) => apiClient.patch(`/cxc/pagos/${id}/`, data);
 export const deletePago = (id) => apiClient.delete(`/cxc/pagos/${id}/`);
-export const exportPagosExcel = (columns) =>
-  apiClient.post('/cxc/pagos/exportar-excel/', { columns }, { responseType: 'blob' });
+export const exportPagosExcel = (columns, filters = {}) =>
+  apiClient.post('/cxc/pagos/exportar-excel/', { columns }, { params: filters, responseType: 'blob' });
 export const importarPagosHistoricos = (formData) =>
   apiClient.post('/cxc/pagos/importar-excel/', formData, {
     headers: { 'Content-Type': 'multipart/form-data' },


### PR DESCRIPTION
## Summary
- include payment plan and payment exports in report page
- allow API to filter and export payment and payment plan data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace5e3e158833293310da211e39000