### PR TITLE
Fix commission scheme loading and reuse audit export button

### DIFF
--- a/frontend/luximia_erp_ui/app/(catalogos)/esquemas-comision/page.jsx
+++ b/frontend/luximia_erp_ui/app/(catalogos)/esquemas-comision/page.jsx
@@ -35,7 +35,7 @@ const ESQUEMA_COLUMNAS_EXPORT = [
 
 export default function EsquemasComisionPage() {
     const { hasPermission, authTokens } = useAuth();
-    const pageSize = useResponsivePageSize();
+    const { ref, pageSize } = useResponsivePageSize(57);
 
     const [pageData, setPageData] = useState({ results: [], count: 0 });
     const [currentPage, setCurrentPage] = useState(1);
@@ -195,7 +195,7 @@ export default function EsquemasComisionPage() {
                 {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
             </div>
 
-            <div className="flex-grow min-h-0">
+            <div ref={ref} className="flex-grow min-h-0">
                 <ReusableTable
                     data={pageData.results}
                     columns={ESQUEMA_COLUMNAS_DISPLAY}

--- a/frontend/luximia_erp_ui/app/(configuraciones)/auditoria/page.jsx
+++ b/frontend/luximia_erp_ui/app/(configuraciones)/auditoria/page.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import ReusableTable from '@/components/ui/tables/ReusableTable';
 import { useAuth } from '@/context/AuthContext';
 import { getAuditLogs, downloadAuditLogExcel } from '@/services/api';
+import ActionButtons from '@/components/ui/ActionButtons';
 
 const COLUMNAS = [
   { header: 'Usuario', render: row => row.user || '-' },
@@ -48,7 +49,7 @@ export default function AuditoriaPage() {
     fetchLogs(newPage, pageSize, true);
   };
 
-  const handleDownload = async () => {
+  const handleExport = async () => {
     try {
       const res = await downloadAuditLogExcel();
       const url = window.URL.createObjectURL(new Blob([res.data]));
@@ -70,7 +71,7 @@ export default function AuditoriaPage() {
     <div className="p-8 h-full flex flex-col">
       <div className="flex justify-between items-center mb-10">
         <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-200">Auditoría</h1>
-        <button onClick={handleDownload} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">Descargar Excel</button>
+        <ActionButtons onExport={handleExport} canExport={hasPermission('cxc.can_view_auditlog')} />
       </div>
       {error && <p className="text-red-500 bg-red-100 p-4 rounded-md mb-4">{error}</p>}
       <div className="flex-grow min-h-0">


### PR DESCRIPTION
## Summary
- fix commission schemes page loading loop by properly initializing responsive page size hook
- replace audit page export button with reusable action button

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `pytest` (fails: Requested setting REST_FRAMEWORK, but settings are not configured)


------
https://chatgpt.com/codex/tasks/task_e_68add811cf9c83328fc72f771290f25a