### PR TITLE
Use VectorField dimensions parameter for DocumentEmbedding

### DIFF
--- a/backend/cxc/migrations/0003_alter_documentembedding_embedding.py
+++ b/backend/cxc/migrations/0003_alter_documentembedding_embedding.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+import pgvector.django
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cxc', '0002_document_embedding'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='documentembedding',
+            name='embedding',
+            field=pgvector.django.fields.VectorField(dimensions=1536),
+        ),
+    ]

--- a/backend/cxc/models.py
+++ b/backend/cxc/models.py
@@ -286,7 +286,7 @@ class DocumentEmbedding(models.Model):
     """Documento indexado para búsquedas semánticas."""
 
     content = models.TextField()
-    embedding = VectorField(dim=1536)
+    embedding = VectorField(dimensions=1536)
 
     def __str__(self):
         return self.content[:50]


### PR DESCRIPTION
## Summary
- fix `DocumentEmbedding` model to use `VectorField(dimensions=1536)`
- add migration updating the `embedding` field

## Testing
- `docker compose exec backend python manage.py makemigrations cxc` *(fails: command not found: docker)*
- `docker compose exec backend python manage.py migrate` *(fails: command not found: docker)*
- `docker compose exec backend python manage.py runscript cxc.seed` *(fails: command not found: docker)*
- `python manage.py makemigrations cxc` *(fails: ModuleNotFoundError: No module named 'pgvector')*
- `pip install pgvector` *(fails: Could not find a version that satisfies the requirement pgvector)*
- `python manage.py runscript cxc.seed` *(fails: ModuleNotFoundError: No module named 'pgvector')*

------
https://chatgpt.com/codex/tasks/task_e_68adfc7ac2a48332bc1e534b5deebdd8