### PR TITLE
fix: avoid dashboard chart label error

### DIFF
--- a/frontend/luximia_erp_ui/app/(main)/dashboard/page.jsx
+++ b/frontend/luximia_erp_ui/app/(main)/dashboard/page.jsx
@@ -29,15 +29,16 @@ export default function DashboardPage() {
         getAllProyectos(),
       ]);
 
-      const labels = dashboardRes.data?.chart?.labels;
+      const dashboard = dashboardRes.data ?? {};
+      const labels = dashboard.chart?.labels;
       if (!labels || labels.length === 0) {
         setHasData(false);
-        console.error('Dashboard response missing chart labels:', dashboardRes);
+        console.warn('Dashboard response missing chart labels', dashboard);
       } else {
         setHasData(true);
       }
 
-      setDashboardData(dashboardRes.data);
+      setDashboardData(dashboard);
       const projectList = proyectosRes.data?.results ?? proyectosRes.data ?? [];
       setProyectos(projectList);
 


### PR DESCRIPTION
## Summary
- handle missing dashboard chart labels without throwing a console error

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae1f5d1a68833289a75b0875088ba3