### PR TITLE
feat: switch to Azure Communication Services for email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,7 +67,11 @@ LOG_LEVEL=INFO
 # -----------------------------------------
 # Email para Desarrollo (MailHog)
 # -----------------------------------------
-# En producción, cambia estos valores por los de tu proveedor de email (ej. SendGrid).
+# En producción, utiliza los datos de Azure Communication Services.
 EMAIL_HOST=mailhog
 EMAIL_PORT=1025
 DEFAULT_FROM_EMAIL=noreply@luximia.local
+
+# Variables para Azure Communication Services
+AZURE_COMMUNICATION_CONNECTION_STRING=tu_cadena_de_conexion
+AZURE_COMMUNICATION_SENDER_ADDRESS=tu_direccion_verificada@tudominio.com

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Desarrollar un sistema web interno para **Grupo Luximia** que centralice y autom
 * **Migraciones Limpias:** Se depuraron migraciones y modelos duplicados para garantizar una base de datos consistente y escalable.
 
 ### 1.3. Stack Tecnológico
-* **Backend:** Python 3.11 con **Django 5** y **Django Rest Framework**. Autenticación con **djangorestframework-simplejwt**, envíos de correo mediante **django-anymail**, y seguridad reforzada con **django-cors-headers** y **django-csp**. Los reportes se generan con **WeasyPrint** (PDF) y **XlsxWriter** (Excel), se soportan passkeys a través de **webauthn** y el procesamiento de datos se realiza con **Polars**.
+* **Backend:** Python 3.11 con **Django 5** y **Django Rest Framework**. Autenticación con **djangorestframework-simplejwt**, envíos de correo mediante **Azure Communication Services**, y seguridad reforzada con **django-cors-headers** y **django-csp**. Los reportes se generan con **WeasyPrint** (PDF) y **XlsxWriter** (Excel), se soportan passkeys a través de **webauthn** y el procesamiento de datos se realiza con **Polars**.
 * **Frontend:** JavaScript con **Next.js 15**, **React 19** y **Tailwind CSS 4**. Consumo de API con **axios**, gráficas interactivas con **@tremor/react**, iconografía con **lucide-react** y autenticación sin contraseñas mediante **@simplewebauthn/browser**.
 * **Base de Datos:** PostgreSQL.
 * **Contenerización:** **Docker** y **Docker Compose**.

--- a/backend/luximia_erp/emails.py
+++ b/backend/luximia_erp/emails.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+from typing import Sequence
+
+from azure.communication.email import EmailClient
+from django.conf import settings
+
+
+def send_mail(
+    subject: str,
+    message: str,
+    from_email: str | None,
+    recipient_list: Sequence[str],
+    fail_silently: bool = False,
+    html_message: str | None = None,
+    **kwargs,
+) -> int:
+    """Send an email using Azure Communication Services.
+
+    Returns the number of successfully delivered messages (1 or 0).
+    """
+    connection_string = getattr(
+        settings,
+        "AZURE_COMMUNICATION_CONNECTION_STRING",
+        os.getenv("AZURE_COMMUNICATION_CONNECTION_STRING"),
+    )
+    sender = from_email or getattr(
+        settings,
+        "AZURE_COMMUNICATION_SENDER_ADDRESS",
+        os.getenv("AZURE_COMMUNICATION_SENDER_ADDRESS"),
+    )
+
+    if not connection_string or not sender:
+        if fail_silently:
+            return 0
+        raise RuntimeError("Azure Communication Services is not configured")
+
+    try:
+        client = EmailClient.from_connection_string(connection_string)
+        email_message = {
+            "senderAddress": sender,
+            "recipients": {"to": [{"address": addr} for addr in recipient_list]},
+            "content": {"subject": subject, "plainText": message},
+        }
+        if html_message:
+            email_message["content"]["html"] = html_message
+        poller = client.begin_send(email_message)
+        poller.result()
+        return 1
+    except Exception:
+        if fail_silently:
+            return 0
+        raise

--- a/backend/luximia_erp/settings.py
+++ b/backend/luximia_erp/settings.py
@@ -214,9 +214,13 @@ if DEBUG:
     DEFAULT_FROM_EMAIL = os.getenv(
         'DEFAULT_FROM_EMAIL', 'desarrollo@luximia.local')
 else:
-    EMAIL_BACKEND = 'anymail.backends.sendgrid.EmailBackend'
-    ANYMAIL = {"SENDGRID_API_KEY": os.getenv("SENDGRID_API_KEY")}
-    DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL")
+    AZURE_COMMUNICATION_CONNECTION_STRING = os.getenv(
+        "AZURE_COMMUNICATION_CONNECTION_STRING"
+    )
+    AZURE_COMMUNICATION_SENDER_ADDRESS = os.getenv(
+        "AZURE_COMMUNICATION_SENDER_ADDRESS"
+    )
+    DEFAULT_FROM_EMAIL = AZURE_COMMUNICATION_SENDER_ADDRESS
 
 
 # --- Django REST Framework y JWT ---

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,7 +17,6 @@ cssselect2==0.8.0
 distro==1.9.0
 dj-database-url==3.0.1
 Django==5.2.4
-django-anymail==13.0.1
 django-cors-headers==4.7.0
 django-csp==4.0
 django-db-connection-pool==1.2.6

--- a/backend/users/management/commands/create_and_invite_superuser.py
+++ b/backend/users/management/commands/create_and_invite_superuser.py
@@ -7,10 +7,11 @@ import secrets
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
-from django.core.mail import send_mail
+from luximia_erp.emails import send_mail
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 from django.db import transaction
+from django.template.loader import render_to_string
 from users.models import EnrollmentToken
 
 class Command(BaseCommand):
@@ -79,16 +80,20 @@ class Command(BaseCommand):
                 protocol = "https" if not settings.DEVELOPMENT_MODE else "http"
                 enroll_url = f"{protocol}://{domain}/enroll/{token}"
 
+                context = {"enroll_url": enroll_url}
+                plain_message = render_to_string(
+                    "users/welcome_invitation.txt", context
+                )
+                html_message = render_to_string(
+                    "users/welcome_invitation.html", context
+                )
                 send_mail(
                     "Invitación para Administrador de Luximia ERP",
-                    (
-                        "Has sido invitado para ser el superusuario de la plataforma Luximia ERP.\n\n"
-                        f"Usa el siguiente enlace para completar tu registro: {enroll_url}\n\n"
-                        "Este enlace expira en 24 horas."
-                    ),
+                    plain_message,
                     settings.DEFAULT_FROM_EMAIL,
                     [email],
                     fail_silently=False,
+                    html_message=html_message,
                 )
                 self.stdout.write(self.style.SUCCESS(
                     f"Invitación de superusuario enviada a {email}."))

--- a/backend/users/templates/users/welcome_invitation.html
+++ b/backend/users/templates/users/welcome_invitation.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="es">
+  <body>
+    <p>Hola,</p>
+    <p>Bienvenido a Luximia ERP. Has sido invitado a la plataforma.</p>
+    <p>Para completar tu registro, haz clic en el siguiente enlace:</p>
+    <p><a href="{{ enroll_url }}">Completar registro</a></p>
+    <p>Este enlace expira en 24 horas.</p>
+    <p>¡Te esperamos!</p>
+  </body>
+</html>

--- a/backend/users/templates/users/welcome_invitation.txt
+++ b/backend/users/templates/users/welcome_invitation.txt
@@ -1,0 +1,10 @@
+Hola,
+
+Bienvenido a Luximia ERP. Has sido invitado a la plataforma.
+
+Completa tu registro con el siguiente enlace:
+{{ enroll_url }}
+
+Este enlace expira en 24 horas.
+
+¡Te esperamos!

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -19,9 +19,10 @@ from django.contrib.auth.models import Group, Permission
 from django.core import signing
 from django.http import HttpRequest, Http404
 from django.db import transaction
-from django.core.mail import send_mail
+from luximia_erp.emails import send_mail
 from datetime import timedelta
 from django.utils import timezone
+from django.template.loader import render_to_string
 
 from rest_framework import permissions, status, generics
 from rest_framework.response import Response
@@ -155,16 +156,20 @@ class InviteUserView(APIView):
         protocol = "https" if not settings.DEVELOPMENT_MODE else "http"
         enroll_url = f"{protocol}://{domain}/enroll/{token}"
 
+        context = {"enroll_url": enroll_url}
+        plain_message = render_to_string(
+            "users/welcome_invitation.txt", context
+        )
+        html_message = render_to_string(
+            "users/welcome_invitation.html", context
+        )
         send_mail(
             "Invitación a Luximia ERP",
-            (
-                "Has sido invitado a la plataforma Luximia ERP.\n\n"
-                f"Usa el siguiente enlace para completar tu registro: {enroll_url}\n\n"
-                "Este enlace expira en 24 horas."
-            ),
+            plain_message,
             settings.DEFAULT_FROM_EMAIL,
             [user.email],
             fail_silently=False,
+            html_message=html_message,
         )
 
     def post(self, request, pk=None):


### PR DESCRIPTION
## Summary
- replace SendGrid configuration with Azure Communication Services
- add helper to send email via ACS and update usages
- document new ACS env vars and remove django-anymail dependency
- template welcome invitation emails and send them as HTML via ACS

## Testing
- `python manage.py test` *(fails: The SECRET_KEY setting must not be empty.)*

------
https://chatgpt.com/codex/tasks/task_e_68af58ebabe88332a209df603339a95f